### PR TITLE
Change default maxLines to null

### DIFF
--- a/lib/src/widgets/reactive_text_field.dart
+++ b/lib/src/widgets/reactive_text_field.dart
@@ -107,7 +107,7 @@ class ReactiveTextField extends ReactiveFormField {
     SmartQuotesType smartQuotesType,
     bool enableSuggestions = true,
     bool maxLengthEnforced = true,
-    int maxLines = 1,
+    int maxLines,
     int minLines,
     bool expands = false,
     int maxLength,


### PR DESCRIPTION
Change default maxLines to null on ReactiveTextField to dynamically change the height of the field when new lines are added as default behavior.