### PR TITLE
Feature: Custom format for datepicker control value

### DIFF
--- a/lib/src/value_accessors/formatted_datetime_value_acessor.dart
+++ b/lib/src/value_accessors/formatted_datetime_value_acessor.dart
@@ -1,0 +1,27 @@
+import 'package:intl/intl.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+/// Represents a control value accessor that converts from a user formatted
+/// date string value to a [DateTime] data type.
+///
+/// This control value accessor is used by [ReactiveDatePicker] when the model
+/// control is of type [String] AND [format] is provided.
+class FormattedDateTimeValueAccessor
+    extends ControlValueAccessor<String, DateTime> {
+
+  FormattedDateTimeValueAccessor(this.format);
+
+  final DateFormat format;
+  
+  @override
+  DateTime modelToViewValue(String modelValue) {
+    return modelValue == null || modelValue.trim().isEmpty
+        ? null
+        : format.parseLoose(modelValue);
+  }
+
+  @override
+  String viewToModelValue(DateTime viewValue) {
+    return viewValue == null ? null : format.format(viewValue);
+  }
+}

--- a/lib/src/value_accessors/iso8601_datetime_value_accessor.dart
+++ b/lib/src/value_accessors/iso8601_datetime_value_accessor.dart
@@ -1,6 +1,6 @@
 import 'package:reactive_forms/reactive_forms.dart';
 
-/// Represents a control value accessor that convert from Iso8601 string value
+/// Represents a control value accessor that converts from Iso8601 string value
 /// to a [DateTime] data type.
 ///
 /// This control value accessor is used by [ReactiveDatePicker] when the model

--- a/lib/src/widgets/reactive_date_picker.dart
+++ b/lib/src/widgets/reactive_date_picker.dart
@@ -4,6 +4,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:reactive_forms/reactive_forms.dart';
+import 'package:intl/intl.dart' hide TextDirection;
+import 'package:reactive_forms/src/value_accessors/formatted_datetime_value_acessor.dart';
 
 /// A builder that builds a widget responsible to decide when to show
 /// the picker dialog.
@@ -77,6 +79,7 @@ class ReactiveDatePicker extends ReactiveFormField<dynamic> {
     String fieldHintText,
     String fieldLabelText,
     Widget child,
+    this.format,
   })  : assert(builder != null),
         super(
           key: key,
@@ -118,6 +121,12 @@ class ReactiveDatePicker extends ReactiveFormField<dynamic> {
           },
         );
 
+  /// DateFormat used on the [DateTime] object returned from the [DatePicker]
+  /// to obtain a customized date string for the control value.
+  /// 
+  /// If used with a form control of type [DateTime], nothing will happen
+  final DateFormat format;
+
   static DateTime _getInitialDate(DateTime fieldValue, DateTime lastDate) {
     if (fieldValue != null) {
       return fieldValue;
@@ -128,7 +137,7 @@ class ReactiveDatePicker extends ReactiveFormField<dynamic> {
   }
 
   @override
-  ReactiveFormFieldState<dynamic> createState() => _ReactiveDatePickerState();
+  ReactiveFormFieldState<dynamic> createState() => _ReactiveDatePickerState(format);
 }
 
 /// Definition of the function responsible for show the date picker.
@@ -157,9 +166,17 @@ class ReactiveDatePickerDelegate {
 }
 
 class _ReactiveDatePickerState extends ReactiveFormFieldState<dynamic> {
+
+  _ReactiveDatePickerState(this.format);
+
+  final DateFormat format;
+
   @override
   ControlValueAccessor selectValueAccessor() {
     if (this.control is AbstractControl<String>) {
+      if (format != null)
+        return FormattedDateTimeValueAccessor(format);
+
       return Iso8601DateTimeValueAccessor();
     } else if (this.control is AbstractControl<DateTime>) {
       return DefaultValueAccessor();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  intl: ^0.16.1
 
 dev_dependencies:
   flutter_test:

--- a/test/src/widgets/reactive_date_picker_testing_widget.dart
+++ b/test/src/widgets/reactive_date_picker_testing_widget.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class ReactiveDatePickerTestingWidget extends StatelessWidget {
   final FormGroup form;
   final DateTime lastDate;
+  final DateFormat format;
 
   const ReactiveDatePickerTestingWidget({
     Key key,
     @required this.form,
     this.lastDate,
+    this.format,
   }) : super(key: key);
 
   @override
@@ -21,6 +24,7 @@ class ReactiveDatePickerTestingWidget extends StatelessWidget {
             formControlName: 'birthday',
             firstDate: DateTime(1985),
             lastDate: lastDate ?? DateTime(2050),
+            format: format,
             builder: (context, picker, child) {
               return FlatButton(
                 onPressed: picker.showPicker,


### PR DESCRIPTION
Hi! First i'd like to thank you for your tremendous work on this package!!

I encountered this use-case when i was using this package to render dynamic forms from JSON. Sometimes i need the date in a specific format for specific uses (not a long, complicated ISO86 string), and the easiest way for me to do that was if, when i build the form, apply the dateformat configuration from the JSON schema directly to the field, needing no other work.

Being so, i can easily just throw around the `form.value` and use it as needed, insted of a ISO86 string.
Feel free to suggest any changes, if its a viable feature to be merged!

Thanks