### PR TITLE
Allow developers to add custom controls

### DIFF
--- a/lib/src/models/form_control_collection.dart
+++ b/lib/src/models/form_control_collection.dart
@@ -48,7 +48,7 @@ abstract class FormControlCollection<T> {
   /// Walks the [path] to find the matching control.
   ///
   /// Returns null if no match is found.
-  AbstractControl<Object>? findControl(List<String> path) {
+  AbstractControl<Object>? findControlInCollection(List<String> path) {
     if (path.isEmpty) {
       return null;
     }


### PR DESCRIPTION
Hi @joanpablo,

this is a small PR that makes a couple methods `@protected` to allow developers to extend and create own types of controls.
Closes #162.