### PR TITLE
Replace pedantic with the new lints package

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   language:
@@ -10,78 +10,24 @@ analyzer:
 linter:
   rules:
     - always_declare_return_types
-    # - avoid_classes_with_only_static_members
-    - avoid_empty_else
-    - avoid_function_literals_in_foreach_calls
-    - avoid_init_to_null
-    - avoid_null_checks_in_equality_operators
-    - avoid_relative_lib_imports
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    - avoid_returning_null_for_void
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_types_as_parameter_names
     - avoid_unused_constructor_parameters
-    - await_only_futures
-    - camel_case_types
     - cancel_subscriptions
-    - constant_identifier_names
-    - control_flow_in_finally
-    - curly_braces_in_flow_control_structures
+    - cast_nullable_to_non_nullable
     - directives_ordering
-    - empty_catches
-    - empty_constructor_bodies
-    - empty_statements
-    - file_names
-    - hash_and_equals
-    - implementation_imports
-    - iterable_contains_unrelated_type
-    - library_names
-    - library_prefixes
-    - list_remove_unrelated_type
     - literal_only_boolean_expressions
-    - no_duplicate_case_values
-    - non_constant_identifier_names
-    - null_closures
+    - null_check_on_nullable_type_parameter
     - omit_local_variable_types
     - only_throw_errors
-    - overridden_fields
     - package_api_docs
-    - package_names
-    - package_prefixed_library_names
-    - prefer_adjacent_string_concatenation
-    - prefer_conditional_assignment
     - prefer_const_constructors
-    - prefer_contains
-    - prefer_equal_for_default_values
-    - prefer_final_fields
-    - prefer_generic_function_type_aliases
-    - prefer_initializing_formals
     - prefer_interpolation_to_compose_strings
-    - prefer_iterable_whereType
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_null_aware_operators
-    - prefer_typing_uninitialized_variables
-    - recursive_getters
-    - slash_for_doc_comments
     - test_types_in_equals
     - throw_in_finally
-    - type_init_formals
     - unawaited_futures
-    - unnecessary_brace_in_string_interps
-    - unnecessary_const
-    - unnecessary_getters_setters
     - unnecessary_lambdas
-    - unnecessary_new
     - unnecessary_null_aware_assignments
-    - unnecessary_null_in_if_null_operators
+    - unnecessary_null_checks
+    - unnecessary_nullable_for_final_variable_declarations
     - unnecessary_parenthesis
     - unnecessary_statements
-    - unnecessary_this
-    - unrelated_type_equality_checks
-    - use_function_type_syntax_for_parameters
-    - use_rethrow_when_possible
-    - valid_regexps
-    - void_checks
+    - use_late_for_private_fields_and_variables

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   reactive_date_time_picker: ^0.1.3
 
 dev_dependencies:
-  pedantic: ^1.11.1
+  lints: ^1.0.1
   flutter_test:
     sdk: flutter
 

--- a/lib/src/models/form_builder.dart
+++ b/lib/src/models/form_builder.dart
@@ -93,8 +93,7 @@ class FormBuilder {
           final validators = List.of(value.skip(1));
 
           if (validators.isNotEmpty &&
-              validators
-                  .any((validator) => !(validator is ValidatorFunction))) {
+              validators.any((validator) => validator is! ValidatorFunction)) {
             throw FormBuilderInvalidInitializationException(
                 'Invalid validators initialization');
           }
@@ -105,6 +104,8 @@ class FormBuilder {
           }
 
           final effectiveValidators = validators
+              // TODO handling should be optimized
+              // ignore: cast_nullable_to_non_nullable
               .map<ValidatorFunction>((v) => v as ValidatorFunction)
               .toList();
           final control = _control(defaultValue, effectiveValidators);

--- a/lib/src/validators/max_length_validator.dart
+++ b/lib/src/validators/max_length_validator.dart
@@ -24,7 +24,7 @@ class MaxLengthValidator extends Validator<dynamic> {
     List<dynamic>? collection;
 
     if (control is FormArray<dynamic>) {
-      collection = control.value!;
+      collection = control.value;
     } else if (control is FormGroup) {
       collection = control.value.keys.toList();
     } else if (control is FormControl<Iterable<dynamic>>) {

--- a/lib/src/validators/min_length_validator.dart
+++ b/lib/src/validators/min_length_validator.dart
@@ -24,7 +24,7 @@ class MinLengthValidator extends Validator<dynamic> {
     List<dynamic>? collection;
 
     if (control is FormArray<dynamic>) {
-      collection = control.value!;
+      collection = control.value;
     } else if (control is FormGroup) {
       collection = control.value.keys.toList();
     } else if (control is FormControl<Iterable<dynamic>>) {

--- a/lib/src/widgets/reactive_form_array.dart
+++ b/lib/src/widgets/reactive_form_array.dart
@@ -57,6 +57,8 @@ class _ReactiveFormArrayState<T> extends State<ReactiveFormArray<T>> {
       _formArray = widget.formArray!;
     } else {
       final form =
+          // TODO handling should be optimized
+          // ignore: cast_nullable_to_non_nullable
           ReactiveForm.of(context, listen: false) as FormControlCollection;
       _formArray = form.control(widget.formArrayName!) as FormArray<T>;
     }
@@ -72,6 +74,9 @@ class _ReactiveFormArrayState<T> extends State<ReactiveFormArray<T>> {
         builder: (context) {
           return widget.builder(
             context,
+            // ReactiveForm.of(context) can not be null here
+            // so we can suppress the lint warning.
+            // ignore: cast_nullable_to_non_nullable
             ReactiveForm.of(context) as FormArray<T>,
             widget.child,
           );

--- a/lib/src/widgets/reactive_status_listenable_builder.dart
+++ b/lib/src/widgets/reactive_status_listenable_builder.dart
@@ -51,7 +51,8 @@ class ReactiveStatusListenableBuilder extends StatelessWidget {
       if (form is! FormControlCollection) {
         throw FormControlParentNotFoundException(this);
       }
-
+      // TODO handling should be optimized
+      // ignore: cast_nullable_to_non_nullable
       final collection = form as FormControlCollection;
       control = collection.control(formControlName!);
     }

--- a/lib/src/widgets/reactive_value_listenable_builder.dart
+++ b/lib/src/widgets/reactive_value_listenable_builder.dart
@@ -57,6 +57,8 @@ class ReactiveValueListenableBuilder<T> extends StatelessWidget {
       if (form is! FormControlCollection) {
         throw FormControlParentNotFoundException(this);
       }
+      // TODO handling should be optimized
+      // ignore: cast_nullable_to_non_nullable
       final collection = form as FormControlCollection;
       control = collection.control(formControlName!) as AbstractControl<T>;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   intl: ^0.17.0
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^1.0.1
   flutter_test:
     sdk: flutter
 

--- a/test/src/exceptions/exception_test.dart
+++ b/test/src/exceptions/exception_test.dart
@@ -23,7 +23,7 @@ void main() {
       final array = FormArray([]);
 
       // Whe trying to remove a control that doesn't belong to array
-      final removeControl = () => array.remove(FormControl());
+      void removeControl() => array.remove(FormControl());
 
       // Then: exception is thrown
       expect(

--- a/test/src/models/form_array_test.dart
+++ b/test/src/models/form_array_test.dart
@@ -445,7 +445,7 @@ void main() {
       array.dispose();
 
       // And: try to change value of children
-      final addValue = () => array.control('0').value = 'some';
+      void addValue() => array.control('0').value = 'some';
 
       // Then: state error
       expect(addValue, throwsStateError);

--- a/test/src/models/form_builder_test.dart
+++ b/test/src/models/form_builder_test.dart
@@ -216,7 +216,7 @@ void main() {
 
     test('Build a group with invalid configuration throws exception', () {
       // Given: a form group builder creation
-      final createGroup = () => fb.group({
+      void createGroup() => fb.group({
             'control': [Validators.required, ''],
           });
 
@@ -228,7 +228,7 @@ void main() {
     test('Build a group with invalid validators configuration throws exception',
         () {
       // Given: a form group builder creation
-      final createGroup = () => fb.group({
+      void createGroup() => fb.group({
             'control': ['', Validators.required, ''],
           });
 

--- a/test/src/models/form_control_test.dart
+++ b/test/src/models/form_control_test.dart
@@ -89,8 +89,8 @@ void main() {
     });
 
     test('Assert error if debounce time < 0', () {
-      final formControl =
-          () => FormControl<dynamic>(asyncValidatorsDebounceTime: -1);
+      void formControl() =>
+          FormControl<dynamic>(asyncValidatorsDebounceTime: -1);
       expect(formControl, throwsAssertionError);
     });
 
@@ -365,8 +365,9 @@ void main() {
       expect(formControl.asyncValidators.isEmpty, true);
 
       // When: setting new async validators
-      final asyncValidator =
-          (AbstractControl<dynamic> control) => Future.value(null);
+      Future<Map<String, dynamic>?> asyncValidator(
+              AbstractControl<dynamic> control) =>
+          Future.value(null);
       formControl.setAsyncValidators([asyncValidator]);
 
       // Then: a new async validator is added

--- a/test/src/models/form_group_test.dart
+++ b/test/src/models/form_group_test.dart
@@ -355,7 +355,7 @@ void main() {
       form.dispose();
 
       // And: try to change value of children
-      final addValue = () => form.control('name').value = 'some';
+      void addValue() => form.control('name').value = 'some';
 
       // Then: state error
       expect(addValue, throwsStateError);
@@ -856,7 +856,7 @@ void main() {
       });
 
       // When: remove a control that does not exists
-      final remove = () => form.removeControl('some other control');
+      void remove() => form.removeControl('some other control');
 
       // Then: controls does not have the email control
       expect(remove, throwsA(isInstanceOf<FormControlNotFoundException>()));

--- a/test/src/validators/compare_validator_test.dart
+++ b/test/src/validators/compare_validator_test.dart
@@ -205,7 +205,7 @@ void main() {
 
     test('Compare with different data types throws exception', () {
       // Given: an invalid form
-      final form = () => fb.group({
+      void form() => fb.group({
             'value1': fb.control<int>(0),
             'value2': fb.control<String>('10'),
           }, [
@@ -259,7 +259,7 @@ void main() {
 
     test('Compare with not comparable data type', () {
       // Given: a form with null values
-      final form = () => fb.group({
+      void form() => fb.group({
             'value1': FormControl<NotComparableClass>(
               value: NotComparableClass(),
             ),

--- a/test/src/value_accessors/control_value_accessor_test.dart
+++ b/test/src/value_accessors/control_value_accessor_test.dart
@@ -30,7 +30,7 @@ void main() {
       final valueAccessor = DummyValueAccessor();
 
       // When: call updateModel before register a control
-      final updateModel = () => valueAccessor.updateModel(null);
+      void updateModel() => valueAccessor.updateModel(null);
 
       // Then: value accessor hold the instance of the control
       expect(updateModel, throwsA(isInstanceOf<ValueAccessorException>()));

--- a/test/src/widgets/reactive_dropdown_field_test.dart
+++ b/test/src/widgets/reactive_dropdown_field_test.dart
@@ -276,9 +276,9 @@ void main() {
 
         // And: a onChanged callback
         var callbackCalled = false;
-        final onChanged = (String? value) {
+        void onChanged(String? value) {
           callbackCalled = true;
-        };
+        }
 
         // And: a widget that is bind to the form
         final items = ['true', 'false'];

--- a/test/src/widgets/reactive_form_field_test.dart
+++ b/test/src/widgets/reactive_form_field_test.dart
@@ -8,7 +8,7 @@ void main() {
       'Assert Error if formControlName is null and formControl is null',
       (WidgetTester tester) async {
         // Given: a ReactiveFormField with formControlName in null
-        final reactiveFormField = () => ReactiveFormField(
+        void reactiveFormField() => ReactiveFormField(
               formControlName: null,
               formControl: null,
               builder: (_) => Container(),

--- a/test/src/widgets/reactive_status_listenable_builder_test.dart
+++ b/test/src/widgets/reactive_status_listenable_builder_test.dart
@@ -113,7 +113,7 @@ void main() {
       'Assert error thrown if formControlName is null',
       (WidgetTester tester) async {
         // Given: a ReactiveValueListenableBuilder with null formControlName
-        final reactiveWidget = () => ReactiveStatusListenableBuilder(
+        void reactiveWidget() => ReactiveStatusListenableBuilder(
               formControlName: null,
               builder: (context, control, child) => Container(),
             );
@@ -195,7 +195,7 @@ void main() {
       'Assert error if formControlName and formControl null',
       (WidgetTester tester) async {
         // Given: the widget null values
-        final statusListenable = () => ReactiveStatusListenableBuilder(
+        void statusListenable() => ReactiveStatusListenableBuilder(
               formControl: null,
               formControlName: null,
               builder: (context, form, child) => Container(),

--- a/test/src/widgets/reactive_text_field_test.dart
+++ b/test/src/widgets/reactive_text_field_test.dart
@@ -388,10 +388,11 @@ void main() {
         // Given: a form with custom validator
         var isControlDirty = false;
 
-        final customValidator = (AbstractControl<dynamic> control) {
+        Map<String, dynamic>? customValidator(
+            AbstractControl<dynamic> control) {
           isControlDirty = control.dirty;
           return null;
-        };
+        }
 
         final form = FormGroup({
           'name': FormControl<String>(validators: [customValidator]),

--- a/test/src/widgets/reactive_value_listenable_builder_test.dart
+++ b/test/src/widgets/reactive_value_listenable_builder_test.dart
@@ -60,7 +60,7 @@ void main() {
       'Assert error thrown if formControlName is null',
       (WidgetTester tester) async {
         // Given: a ReactiveValueListenableBuilder with null formControlName
-        final reactiveWidget = () => ReactiveValueListenableBuilder(
+        void reactiveWidget() => ReactiveValueListenableBuilder(
               formControlName: null,
               builder: (context, control, child) => Container(),
             );
@@ -74,7 +74,7 @@ void main() {
       'Assert error thrown if formControl is null',
       (WidgetTester tester) async {
         // Given: a ReactiveValueListenableBuilder with null formControlName
-        final reactiveWidget = () => ReactiveValueListenableBuilder(
+        void reactiveWidget() => ReactiveValueListenableBuilder(
               formControl: null,
               builder: (context, control, child) => Container(),
             );


### PR DESCRIPTION
* remove rules from `analysis_options.yaml` which are on by default
* add 5 experimental null-safety rules
* fix all resulting warnings