### PR TITLE
dropdown value accessor

### DIFF
--- a/example/lib/samples/complex_sample.dart
+++ b/example/lib/samples/complex_sample.dart
@@ -3,6 +3,21 @@ import 'package:reactive_forms/reactive_forms.dart';
 import 'package:reactive_forms_example/progress_indicator.dart';
 import 'package:reactive_forms_example/sample_screen.dart';
 
+class BoolValueAccessor extends ControlValueAccessor<bool, String> {
+  @override
+  String modelToViewValue(bool? modelValue) {
+    return (modelValue ?? false) ? 'Yes' : 'No';
+  }
+
+  @override
+  bool? viewToModelValue(String? viewValue) {
+    if (viewValue == 'Yes') {
+      return true;
+    }
+    return false;
+  }
+}
+
 class ComplexSample extends StatelessWidget {
   FormGroup buildForm() => fb.group(<String, Object>{
         'email': FormControl<String>(
@@ -98,14 +113,15 @@ class ComplexSample extends StatelessWidget {
                   ReactiveCheckbox(formControlName: 'rememberMe'),
                 ],
               ),
-              ReactiveDropdownField<bool>(
+              ReactiveDropdownField<bool, String>(
                 formControlName: 'rememberMe',
                 decoration: const InputDecoration(
                   labelText: 'Want to stay logged in?',
                 ),
+                valueAccessor: BoolValueAccessor(),
                 items: [
-                  const DropdownMenuItem(value: true, child: Text('Yes')),
-                  const DropdownMenuItem(value: false, child: Text('No')),
+                  const DropdownMenuItem(value: 'Yes', child: Text('Yes')),
+                  const DropdownMenuItem(value: 'No', child: Text('No')),
                 ],
               ),
               ReactiveRadioListTile(

--- a/lib/src/widgets/reactive_dropdown_field.dart
+++ b/lib/src/widgets/reactive_dropdown_field.dart
@@ -7,7 +7,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// A reactive widget that wraps a [DropdownButton].
-class ReactiveDropdownField<T> extends ReactiveFormField<T, T> {
+class ReactiveDropdownField<T, V> extends ReactiveFormField<T, V> {
   /// Creates a [DropdownButton] widget wrapped in an [InputDecorator].
   ///
   /// Can optionally provide a [formControl] to bind this widget to a control.
@@ -26,7 +26,8 @@ class ReactiveDropdownField<T> extends ReactiveFormField<T, T> {
     Key? key,
     String? formControlName,
     FormControl<T>? formControl,
-    required List<DropdownMenuItem<T>> items,
+    ControlValueAccessor<T, V>? valueAccessor,
+    required List<DropdownMenuItem<V>> items,
     ValidationMessagesFunction<T>? validationMessages,
     ShowErrorsFunction? showErrors,
     DropdownButtonBuilder? selectedItemBuilder,
@@ -44,7 +45,6 @@ class ReactiveDropdownField<T> extends ReactiveFormField<T, T> {
     bool isExpanded = false,
     bool readOnly = false,
     double? itemHeight,
-    ValueChanged<T?>? onChanged,
     Color? dropdownColor,
     Color? focusColor,
     Widget? underline,
@@ -55,10 +55,11 @@ class ReactiveDropdownField<T> extends ReactiveFormField<T, T> {
           key: key,
           formControl: formControl,
           formControlName: formControlName,
+          valueAccessor: valueAccessor,
           validationMessages: validationMessages,
           showErrors: showErrors,
-          builder: (ReactiveFormFieldState<T, T> field) {
-            final state = field as _ReactiveDropdownFieldState<T>;
+          builder: (field) {
+            final state = field as _ReactiveDropdownFieldState<T, V>;
 
             final effectiveDecoration = decoration.applyDefaults(
               Theme.of(field.context).inputDecorationTheme,
@@ -90,14 +91,12 @@ class ReactiveDropdownField<T> extends ReactiveFormField<T, T> {
               ),
               isEmpty: effectiveValue == null,
               child: DropdownButtonHideUnderline(
-                child: DropdownButton<T>(
+                child: DropdownButton<V>(
                   value: effectiveValue,
                   items: items,
                   selectedItemBuilder: selectedItemBuilder,
                   hint: hint,
-                  onChanged: isDisabled
-                      ? null
-                      : (T? value) => state._onChanged(value, onChanged),
+                  onChanged: isDisabled ? null : field.didChange,
                   onTap: onTap,
                   disabledHint: effectiveDisabledHint,
                   elevation: elevation,
@@ -122,11 +121,11 @@ class ReactiveDropdownField<T> extends ReactiveFormField<T, T> {
         );
 
   @override
-  ReactiveFormFieldState<T, T> createState() =>
-      _ReactiveDropdownFieldState<T>();
+  ReactiveFormFieldState<T, V> createState() =>
+      _ReactiveDropdownFieldState<T, V>();
 }
 
-class _ReactiveDropdownFieldState<T> extends ReactiveFormFieldState<T, T> {
+class _ReactiveDropdownFieldState<T, V> extends ReactiveFormFieldState<T, V> {
   final _focusController = FocusController();
 
   @override
@@ -140,12 +139,5 @@ class _ReactiveDropdownFieldState<T> extends ReactiveFormFieldState<T, T> {
     control.unregisterFocusController(_focusController);
     _focusController.dispose();
     super.dispose();
-  }
-
-  void _onChanged(T? value, ValueChanged<T?>? callBack) {
-    didChange(value);
-    if (callBack != null) {
-      callBack(value);
-    }
   }
 }

--- a/test/src/widgets/reactive_dropdown_field_test.dart
+++ b/test/src/widgets/reactive_dropdown_field_test.dart
@@ -267,41 +267,6 @@ void main() {
     );
 
     testWidgets(
-      'Set Dropdown on Changed callback',
-      (WidgetTester tester) async {
-        // Given: a form
-        final form = FormGroup({
-          'dropdown': FormControl<String>(),
-        });
-
-        // And: a onChanged callback
-        var callbackCalled = false;
-        void onChanged(String? value) {
-          callbackCalled = true;
-        }
-
-        // And: a widget that is bind to the form
-        final items = ['true', 'false'];
-        await tester.pumpWidget(ReactiveDropdownTestingWidget(
-          form: form,
-          items: items,
-          onChanged: onChanged,
-        ));
-
-        // When: callback on changed in widget
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
-        dropdown.onChanged!('true');
-        await tester.pump();
-
-        // Then: callback is called
-        expect(callbackCalled, true);
-      },
-    );
-
-    testWidgets(
       'A disabled Dropdown uses selectedItemBuilder to show selected item',
       (WidgetTester tester) async {
         // Given: a form with disabled control
@@ -333,6 +298,35 @@ void main() {
 
         // Then: callback is called
         expect(dropdown.disabledHint, selectedItemBuilderList.elementAt(0));
+      },
+    );
+
+    testWidgets(
+      'A disabled Dropdown uses item child to show selected item',
+      (WidgetTester tester) async {
+        // Given: a form with disabled control
+        final items = ['true', 'false'];
+        final form = FormGroup({
+          'dropdown': FormControl<String>(
+            value: items.elementAt(0),
+            disabled: true,
+          ),
+        });
+
+        await tester.pumpWidget(ReactiveDropdownTestingWidget(
+          form: form,
+          items: ['true', 'false'],
+        ));
+
+        // Then: dropdown disabledHint value is equals to selectedItemBuilder
+        // equivalent item
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+
+        expect(dropdown.disabledHint.runtimeType.toString(), 'Text');
+        expect((dropdown.disabledHint as Text?)?.data, 'true');
       },
     );
   });

--- a/test/src/widgets/reactive_dropdown_testing_widget.dart
+++ b/test/src/widgets/reactive_dropdown_testing_widget.dart
@@ -25,9 +25,8 @@ class ReactiveDropdownTestingWidget extends StatelessWidget {
       home: Material(
         child: ReactiveForm(
           formGroup: form,
-          child: ReactiveDropdownField<String>(
+          child: ReactiveDropdownField<String, String>(
             formControlName: 'dropdown',
-            onChanged: onChanged,
             readOnly: readOnly,
             disabledHint: disabledHint,
             selectedItemBuilder: selectedItemBuilder,


### PR DESCRIPTION
Hi, @joanpablo this PR is related to #195 

I added `valueAccessor` to `ReactiveDropdown`

I removed `onChanged` prod overriding possibility cause we do not do this on other widgets
https://github.com/joanpablo/reactive_forms/blob/master/lib/src/widgets/reactive_radio.dart#L55
https://github.com/joanpablo/reactive_forms/blob/master/lib/src/widgets/reactive_switch_list_tile.dart#L56
https://github.com/joanpablo/reactive_forms/blob/master/lib/src/widgets/reactive_switch.dart#L64
https://github.com/joanpablo/reactive_forms/blob/master/lib/src/widgets/reactive_slider.dart#L64

So this unifies the API