### PR TITLE
Allow selecting all text in a ReactiveTextField when gaining focus

### DIFF
--- a/lib/src/widgets/reactive_text_field.dart
+++ b/lib/src/widgets/reactive_text_field.dart
@@ -21,6 +21,10 @@ import 'package:reactive_forms/src/value_accessors/int_value_accessor.dart';
 /// A [ReactiveForm] ancestor is required.
 ///
 class ReactiveTextField<T> extends ReactiveFormField<T, String> {
+
+  /// If true, when gaining focus all text will be selected.
+  final bool selectAllOnFocus;
+
   /// Creates a [ReactiveTextField] that contains a [TextField].
   ///
   /// Can optionally provide a [formControl] to bind this widget to a control.
@@ -101,6 +105,7 @@ class ReactiveTextField<T> extends ReactiveFormField<T, String> {
     TextAlign textAlign = TextAlign.start,
     TextAlignVertical? textAlignVertical,
     bool autofocus = false,
+    this.selectAllOnFocus = false,
     bool readOnly = false,
     ToolbarOptions? toolbarOptions,
     bool? showCursor,
@@ -274,13 +279,27 @@ class _ReactiveTextFieldState<T> extends ReactiveFormFieldState<T, String> {
     return super.selectValueAccessor();
   }
 
+  void _focusListener() {
+    final widget = this.widget;
+    if (mounted &&
+        widget is ReactiveTextField &&
+        (widget as ReactiveTextField).selectAllOnFocus) {
+      _textController.selection = TextSelection(
+        baseOffset: 0,
+        extentOffset: _textController.text.length,
+      );
+    }
+  }
+
   void _registerFocusController(FocusController focusController) {
     _focusController = focusController;
     control.registerFocusController(focusController);
+    _focusController.addListener(_focusListener);
   }
 
   void _unregisterFocusController() {
     control.unregisterFocusController(_focusController);
+    _focusController.removeListener(_focusListener);
     _focusController.dispose();
   }
 


### PR DESCRIPTION
Hi @joanpablo, 

This PR is based on a requirement for our app [Eggy](https://eggy.as). I have outlined the problem in a use case below.

Opening this PR now for review of the API. We have taken the shortest path to solve our specific use case and are more than happy to adjust the solution to better fit the design goals of the library.

Re tests: once you are happy with the solution I will add tests to maintain test coverage.

Thank you for your work on this library and its corresponding contribution to the Flutter community!!! 😀

Use Case
---
We have a form that in certain circumstances pre-populates some of the fields with a default value, e.g. the name of a file that is being imported. When this pre-population occurs we want to allow users to easily replace the pre-populated value with a different value without having to manually select all since this can be quite awkward for really long values in small text inputs.