### PR TITLE
export inherited streamer

### DIFF
--- a/lib/reactive_forms.dart
+++ b/lib/reactive_forms.dart
@@ -34,6 +34,7 @@ export 'src/value_accessors/int_value_accessor.dart';
 export 'src/value_accessors/iso8601_datetime_value_accessor.dart';
 export 'src/value_accessors/slider_int_value_accessor.dart';
 export 'src/value_accessors/time_of_day_value_accessor.dart';
+export 'src/widgets/inherited_streamer.dart';
 export 'src/widgets/reactive_checkbox.dart';
 export 'src/widgets/reactive_checkbox_list_tile.dart';
 export 'src/widgets/reactive_date_picker.dart';


### PR DESCRIPTION
This is relatively small PR that exports `inrerited_streamer`.
When I generate the code with `reacitve_forms_generator` I need to import two files instead of one.
This will simplify the flow

![image](https://user-images.githubusercontent.com/6721286/142470292-d353d0f3-29c1-464a-9cbe-934f6266b504.png)
