### PR TITLE
Added child control type casting using generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ print(form.value);
 Let's dynamically add another control:
 
 ```dart
-final array = form.control('emails') as FormArray<String>;
+final array = form.control<FormArray<String>>('emails');
 
 // adding another email
 array.add(
@@ -617,7 +617,7 @@ final form = FormGroup({
 });
 
 // get the array of controls
-final formArray = form.control('selectedEmails') as FormArray<bool>;
+final formArray = form.control<FormArray<bool>>('selectedEmails');
 
 // populates the array of controls.
 // for each contact add a boolean form control to the array.

--- a/example/lib/samples/array_sample.dart
+++ b/example/lib/samples/array_sample.dart
@@ -14,10 +14,10 @@ class _ArraySampleState extends State<ArraySample> {
   });
 
   FormArray<bool> get selectedContacts =>
-      form.control('selectedContacts') as FormArray<bool>;
+      form.control<FormArray<bool>>('selectedContacts');
 
   FormControl<bool> selectedContactsItem(int i) =>
-      form.control('selectedContacts.$i') as FormControl<bool>;
+      form.control<FormControl<bool>>('selectedContacts.$i');
 
   @override
   void initState() {

--- a/lib/src/exceptions/control_cast_exception.dart
+++ b/lib/src/exceptions/control_cast_exception.dart
@@ -1,0 +1,12 @@
+import 'package:reactive_forms/reactive_forms.dart';
+
+class ControlCastException<E> extends ReactiveFormsException {
+  final AbstractControl<dynamic> control;
+
+  ControlCastException(this.control);
+
+  @override
+  String toString() {
+    return 'ChildControlCastException: Tried to cast control of type "${control.runtimeType}" as "$E"';
+  }
+}

--- a/lib/src/models/form_control_collection.dart
+++ b/lib/src/models/form_control_collection.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:reactive_forms/reactive_forms.dart';
+import 'package:reactive_forms/src/exceptions/control_cast_exception.dart';
 
 /// The base class form [FormGroup] and [FormArray].
 /// Its provides methods for get a control by name and a [Listenable]
@@ -21,6 +22,9 @@ abstract class FormControlCollection<T> {
   ///
   /// Throws [FormControlNotFoundException] if no control founded with
   /// the specified [name]/path.
+  ///
+  /// Throws [ControlCastException] if the type of the control [name] does not
+  /// match [F]
   F control<F extends AbstractControl<dynamic>>(String name);
 
   /// Checks if collection contains a control by a given [name].

--- a/lib/src/models/form_control_collection.dart
+++ b/lib/src/models/form_control_collection.dart
@@ -21,7 +21,7 @@ abstract class FormControlCollection<T> {
   ///
   /// Throws [FormControlNotFoundException] if no control founded with
   /// the specified [name]/path.
-  AbstractControl<dynamic> control(String name);
+  F control<F extends AbstractControl<dynamic>>(String name);
 
   /// Checks if collection contains a control by a given [name].
   ///

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:reactive_forms/reactive_forms.dart';
+import 'package:reactive_forms/src/exceptions/control_cast_exception.dart';
 
 const _controlNameDelimiter = '.';
 
@@ -1118,15 +1119,24 @@ class FormGroup extends AbstractControl<Map<String, Object?>>
   /// form.control('person.name');
   /// ```
   @override
-  AbstractControl<dynamic> control(String name) {
+  F control<F extends AbstractControl<dynamic>>(String name) {
     final namePath = name.split(_controlNameDelimiter);
     if (namePath.length > 1) {
       final control = findControlInCollection(namePath);
       if (control != null) {
-        return control;
+        if (control is! F) {
+          throw ControlCastException<F>(control);
+        }
+
+        return control as F;
       }
     } else if (contains(name)) {
-      return _controls[name]!;
+      final control = _controls[name];
+      if (control is! F) {
+        throw ControlCastException<F>(control!);
+      }
+
+      return control;
     }
 
     throw FormControlNotFoundException(controlName: name);
@@ -1883,19 +1893,28 @@ class FormArray<T> extends AbstractControl<List<T?>>
   /// form.control('address.0.city');
   /// ```
   @override
-  AbstractControl<dynamic> control(String name) {
+  F control<F extends AbstractControl<dynamic>>(String name) {
     final namePath = name.split(_controlNameDelimiter);
     if (namePath.length > 1) {
       final control = findControlInCollection(namePath);
       if (control != null) {
-        return control;
+        if (control is! F) {
+          throw ControlCastException<F>(control);
+        }
+
+        return control as F;
       }
     } else {
       final index = int.tryParse(name);
       if (index == null) {
         throw FormArrayInvalidIndexException(name);
       } else if (index < _controls.length) {
-        return _controls[index];
+        final control = _controls[index];
+        if (control is! F) {
+          throw ControlCastException<F>(control);
+        }
+
+        return control as F;
       }
     }
 

--- a/lib/src/widgets/reactive_form.dart
+++ b/lib/src/widgets/reactive_form.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:reactive_forms/reactive_forms.dart';
+import 'package:reactive_forms/src/exceptions/control_cast_exception.dart';
 
 import '../widgets/form_control_inherited_notifier.dart';
 
@@ -45,19 +46,30 @@ class ReactiveForm extends StatelessWidget {
   ///
   /// `listen: false` is necessary if want to avoid rebuilding the
   /// [context] when model changes:
-  static AbstractControl<Object>? of(BuildContext context,
+  static F? of<F extends AbstractControl<dynamic>>(BuildContext context,
       {bool listen = true}) {
     if (listen) {
-      return context
+      final control = context
           .dependOnInheritedWidgetOfExactType<FormControlInheritedStreamer>()
           ?.control;
+      if (control is! F?) {
+        throw ControlCastException<F>(control);
+      }
+
+      return control as F?;
     }
 
     final element = context.getElementForInheritedWidgetOfExactType<
         FormControlInheritedStreamer>();
-    return element == null
+    final control = element == null
         ? null
         : (element.widget as FormControlInheritedStreamer).control;
+
+    if (control is! F?) {
+      throw ControlCastException<F>(control);
+    }
+
+    return control as F?;
   }
 
   @override

--- a/lib/src/widgets/reactive_form.dart
+++ b/lib/src/widgets/reactive_form.dart
@@ -46,7 +46,7 @@ class ReactiveForm extends StatelessWidget {
   ///
   /// `listen: false` is necessary if want to avoid rebuilding the
   /// [context] when model changes:
-  static F? of<F extends AbstractControl<dynamic>>(BuildContext context,
+  static F? of<F extends AbstractControl<Object>>(BuildContext context,
       {bool listen = true}) {
     if (listen) {
       final control = context
@@ -56,7 +56,7 @@ class ReactiveForm extends StatelessWidget {
         throw ControlCastException<F>(control);
       }
 
-      return control as F?;
+      return control;
     }
 
     final element = context.getElementForInheritedWidgetOfExactType<
@@ -69,7 +69,7 @@ class ReactiveForm extends StatelessWidget {
       throw ControlCastException<F>(control);
     }
 
-    return control as F?;
+    return control;
   }
 
   @override

--- a/lib/src/widgets/reactive_form_array.dart
+++ b/lib/src/widgets/reactive_form_array.dart
@@ -76,7 +76,7 @@ class _ReactiveFormArrayState<T> extends State<ReactiveFormArray<T>> {
         builder: (context) {
           return widget.builder(
             context,
-            ReactiveForm.of(context)! as FormArray<T>,
+            ReactiveForm.of<FormArray<T>>(context)!,
             widget.child,
           );
         },

--- a/test/src/models/form_group_test.dart
+++ b/test/src/models/form_group_test.dart
@@ -848,7 +848,7 @@ void main() {
       });
 
       // When: add control to nested group
-      final address = form.control('address') as FormGroup;
+      final address = form.control<FormGroup>('address');
       address.addAll({
         'city': FormControl<String>(value: 'Sofia'),
       });


### PR DESCRIPTION
Added generic to the `FormControlCollectior.control(String name)` in order to cast the control (the generic must extends `AbstractControl`).
I also added the same thing to `ReactiveForm.of(control)`.

If no generic is specified, it will use the extended class (`AbstractControl<dynamic>`), just like before.

I think this makes it cleaner to access a control of a certain type without having to explicitly cast it.

For example:
```dart
ReactiveForm.of<FormGroup>(context).control<FormControl<int>>("someControl")...

...

final control = formGroup.control<FormControl<bool>>("someControl");
```
instead of
```dart
((ReactiveForm.of(context) as FormGroup).control("someControl") as FormControl<int>)...

...

final control = formGroup.control("sameControl") as FormControl<bool>;
```