### PR TITLE
Fix dropdown field wrapper

### DIFF
--- a/lib/src/widgets/reactive_dropdown_field.dart
+++ b/lib/src/widgets/reactive_dropdown_field.dart
@@ -72,6 +72,7 @@ class ReactiveDropdownField<T> extends ReactiveFocusableFormField<T, T> {
               effectiveValue = null;
             }
 
+
             final isDisabled = readOnly || field.control.disabled;
             var effectiveDisabledHint = disabledHint;
             if (isDisabled && disabledHint == null) {
@@ -85,46 +86,40 @@ class ReactiveDropdownField<T> extends ReactiveFocusableFormField<T, T> {
               }
             }
 
-            return InputDecorator(
+            return DropdownButtonFormField<T>(
+              value: effectiveValue,
               decoration: effectiveDecoration.copyWith(
                 errorText: field.errorText,
                 enabled: !isDisabled,
               ),
-              isEmpty: effectiveValue == null,
-              child: DropdownButtonHideUnderline(
-                child: DropdownButton<T>(
-                  value: effectiveValue,
-                  items: items,
-                  selectedItemBuilder: selectedItemBuilder,
-                  hint: hint,
-                  disabledHint: effectiveDisabledHint,
-                  elevation: elevation,
-                  style: style,
-                  icon: icon,
-                  iconDisabledColor: iconDisabledColor,
-                  iconEnabledColor: iconEnabledColor,
-                  iconSize: iconSize,
-                  isDense: isDense,
-                  isExpanded: isExpanded,
-                  itemHeight: itemHeight,
-                  focusNode: field.focusNode,
-                  dropdownColor: dropdownColor,
-                  focusColor: focusColor,
-                  underline: underline,
-                  autofocus: autofocus,
-                  menuMaxHeight: menuMaxHeight,
-                  enableFeedback: enableFeedback,
-                  alignment: alignment,
-                  borderRadius: borderRadius,
-                  onTap: onTap != null ? () => onTap(field.control) : null,
-                  onChanged: isDisabled
-                      ? null
-                      : (value) {
-                          field.didChange(value);
-                          onChanged?.call(field.control);
-                        },
-                ),
-              ),
+              items: items,
+              selectedItemBuilder: selectedItemBuilder,
+              hint: hint,
+              disabledHint: effectiveDisabledHint,
+              elevation: elevation,
+              style: style,
+              icon: icon,
+              iconDisabledColor: iconDisabledColor,
+              iconEnabledColor: iconEnabledColor,
+              iconSize: iconSize,
+              isDense: isDense,
+              isExpanded: isExpanded,
+              itemHeight: itemHeight,
+              focusNode: field.focusNode,
+              dropdownColor: dropdownColor,
+              focusColor: focusColor,
+              autofocus: autofocus,
+              menuMaxHeight: menuMaxHeight,
+              enableFeedback: enableFeedback,
+              alignment: alignment,
+              borderRadius: borderRadius,
+              onTap: onTap != null ? () => onTap(field.control) : null,
+              onChanged: isDisabled
+                  ? null
+                  : (value) {
+                      field.didChange(value);
+                      onChanged?.call(field.control);
+                    },
             );
           },
         );

--- a/lib/src/widgets/reactive_dropdown_field.dart
+++ b/lib/src/widgets/reactive_dropdown_field.dart
@@ -45,7 +45,6 @@ class ReactiveDropdownField<T> extends ReactiveFocusableFormField<T, T> {
     double? itemHeight,
     Color? dropdownColor,
     Color? focusColor,
-    Widget? underline,
     bool autofocus = false,
     double? menuMaxHeight,
     bool? enableFeedback,
@@ -71,7 +70,6 @@ class ReactiveDropdownField<T> extends ReactiveFocusableFormField<T, T> {
                 !items.any((item) => item.value == effectiveValue)) {
               effectiveValue = null;
             }
-
 
             final isDisabled = readOnly || field.control.disabled;
             var effectiveDisabledHint = disabledHint;

--- a/test/src/widgets/reactive_dropdown_field_test.dart
+++ b/test/src/widgets/reactive_dropdown_field_test.dart
@@ -23,8 +23,10 @@ void main() {
         );
 
         // When: gets dropdown
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         // Expect: dropdown value is null
         expect(dropdown.value, null);
@@ -46,8 +48,10 @@ void main() {
         ));
 
         // When: gets dropdown
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         // Expect: dropdown value is null
         expect(dropdown.value, 'true');
@@ -69,8 +73,10 @@ void main() {
         ));
 
         // When: gets dropdown
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         // Expect: dropdown value is null
         expect(dropdown.value, 'false');
@@ -96,8 +102,10 @@ void main() {
         await tester.pump();
 
         // Then: dropdown value is equals to control
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         expect(dropdown.value, form.control('dropdown').value);
       },
@@ -122,8 +130,10 @@ void main() {
         await tester.pump();
 
         // Then: dropdown value is equals to control
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         expect(dropdown.value, form.control('dropdown').value);
       },
@@ -144,8 +154,10 @@ void main() {
         ));
 
         // Then: the dropdown is disabled
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         expect(dropdown.onChanged, null);
       },
     );
@@ -166,8 +178,10 @@ void main() {
         ));
 
         // Then: the dropdown is disabled
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         expect(dropdown.onChanged, null);
       },
     );
@@ -190,8 +204,10 @@ void main() {
         ));
 
         // Then: the dropdown is disabled
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         expect(dropdown.disabledHint, disabledHint);
       },
     );
@@ -215,8 +231,10 @@ void main() {
         await tester.pump();
 
         // Then: the dropdown is disabled
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         expect(dropdown.onChanged, null);
       },
     );
@@ -240,8 +258,10 @@ void main() {
         await tester.pump();
 
         // Then: the dropdown is enable
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         expect(dropdown.onChanged != null, true);
       },
     );
@@ -272,8 +292,10 @@ void main() {
         ));
 
         // When: callback on changed in widget
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         dropdown.onChanged!('true');
         await tester.pump();
 
@@ -311,8 +333,10 @@ void main() {
         ));
 
         // When: callback on tap in widget
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         dropdown.onTap!();
         await tester.pump();
 
@@ -345,8 +369,10 @@ void main() {
 
         // Then: dropdown disabledHint value is equals to selectedItemBuilder
         // equivalent item
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         // Then: disabled hint is shown
 
@@ -381,8 +407,10 @@ void main() {
 
         // Then: dropdown disabledHint value is equals to selectedItemBuilder
         // equivalent item
-        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType =
+            DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester
+            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         // Then: callback is called
         expect(dropdown.disabledHint, selectedItemBuilderList.elementAt(0));

--- a/test/src/widgets/reactive_dropdown_field_test.dart
+++ b/test/src/widgets/reactive_dropdown_field_test.dart
@@ -23,10 +23,8 @@ void main() {
         );
 
         // When: gets dropdown
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         // Expect: dropdown value is null
         expect(dropdown.value, null);
@@ -48,10 +46,8 @@ void main() {
         ));
 
         // When: gets dropdown
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         // Expect: dropdown value is null
         expect(dropdown.value, 'true');
@@ -73,10 +69,8 @@ void main() {
         ));
 
         // When: gets dropdown
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         // Expect: dropdown value is null
         expect(dropdown.value, 'false');
@@ -102,10 +96,8 @@ void main() {
         await tester.pump();
 
         // Then: dropdown value is equals to control
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         expect(dropdown.value, form.control('dropdown').value);
       },
@@ -130,10 +122,8 @@ void main() {
         await tester.pump();
 
         // Then: dropdown value is equals to control
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         expect(dropdown.value, form.control('dropdown').value);
       },
@@ -154,10 +144,8 @@ void main() {
         ));
 
         // Then: the dropdown is disabled
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         expect(dropdown.onChanged, null);
       },
     );
@@ -178,10 +166,8 @@ void main() {
         ));
 
         // Then: the dropdown is disabled
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         expect(dropdown.onChanged, null);
       },
     );
@@ -204,10 +190,8 @@ void main() {
         ));
 
         // Then: the dropdown is disabled
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         expect(dropdown.disabledHint, disabledHint);
       },
     );
@@ -231,10 +215,8 @@ void main() {
         await tester.pump();
 
         // Then: the dropdown is disabled
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         expect(dropdown.onChanged, null);
       },
     );
@@ -258,10 +240,8 @@ void main() {
         await tester.pump();
 
         // Then: the dropdown is enable
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         expect(dropdown.onChanged != null, true);
       },
     );
@@ -292,10 +272,8 @@ void main() {
         ));
 
         // When: callback on changed in widget
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         dropdown.onChanged!('true');
         await tester.pump();
 
@@ -333,10 +311,8 @@ void main() {
         ));
 
         // When: callback on tap in widget
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
         dropdown.onTap!();
         await tester.pump();
 
@@ -345,6 +321,38 @@ void main() {
 
         // And: with the control as argument
         expect(callbackArg, form.control('dropdown'));
+      },
+    );
+
+    testWidgets(
+      'A disabled Dropdown use items to show selected item',
+      (WidgetTester tester) async {
+        // Given: a form with disabled control
+        final items = ['true', 'false'];
+        final form = FormGroup({
+          'dropdown': FormControl<String>(
+            value: items.elementAt(0),
+            disabled: true,
+          ),
+        });
+
+        // And: a widget that is bound to the form
+
+        await tester.pumpWidget(ReactiveDropdownTestingWidget(
+          form: form,
+          items: ['true', 'false'],
+        ));
+
+        // Then: dropdown disabledHint value is equals to selectedItemBuilder
+        // equivalent item
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+
+        // Then: disabled hint is shown
+
+        final disabledHintFinder = find.byWidget(dropdown.disabledHint!);
+
+        expect(disabledHintFinder, findsWidgets);
       },
     );
 
@@ -373,10 +381,8 @@ void main() {
 
         // Then: dropdown disabledHint value is equals to selectedItemBuilder
         // equivalent item
-        final dropdownType =
-            DropdownButton<String>(items: null, onChanged: null).runtimeType;
-        final dropdown = tester
-            .firstWidget<DropdownButton<String>>(find.byType(dropdownType));
+        final dropdownType = DropdownButton<String>(items: null, onChanged: null).runtimeType;
+        final dropdown = tester.firstWidget<DropdownButton<String>>(find.byType(dropdownType));
 
         // Then: callback is called
         expect(dropdown.disabledHint, selectedItemBuilderList.elementAt(0));


### PR DESCRIPTION
Removed the input decoration implementation in the wrapper and just passed decoration to the drop-down widget, so it handles all the decoration and spacing