### PR TITLE
Const validators

### DIFF
--- a/lib/src/models/form_builder.dart
+++ b/lib/src/models/form_builder.dart
@@ -82,8 +82,13 @@ class FormBuilder {
         return MapEntry(key, value);
       } else if (value is ValidatorFunction) {
         return MapEntry(key, FormControl(validators: [value]));
+      } else if (value is Validator) {
+        return MapEntry(key, FormControl(validators: [value]));
       } else if (value is List<ValidatorFunction>) {
         return MapEntry(key, FormControl(validators: value));
+      } else if (value is List<Validator>) {
+        return MapEntry(
+            key, FormControl(validators: value.map((e) => e.call).toList()));
       } else if (value is List<Object?>) {
         if (value.isEmpty) {
           return MapEntry(key, FormControl());
@@ -92,12 +97,13 @@ class FormBuilder {
           final validators = List.of(value.skip(1));
 
           if (validators.isNotEmpty &&
-              validators.any((validator) => validator is! ValidatorFunction)) {
+              validators.any((validator) => (validator is! ValidatorFunction &&
+                  validator is! Validator))) {
             throw FormBuilderInvalidInitializationException(
                 'Invalid validators initialization');
           }
 
-          if (defaultValue is ValidatorFunction) {
+          if (defaultValue is ValidatorFunction || defaultValue is Validator) {
             throw FormBuilderInvalidInitializationException(
                 'Expected first value in array to be default value of the control and not a validator.');
           }

--- a/lib/src/validators/compare_validator.dart
+++ b/lib/src/validators/compare_validator.dart
@@ -14,7 +14,7 @@ class CompareValidator extends Validator<dynamic> {
   ///
   /// The arguments [controlName], [compareControlName] and [compareOption]
   /// must not be null.
-  CompareValidator(
+  const CompareValidator(
     this.controlName,
     this.compareControlName,
     this.compareOption,

--- a/lib/src/validators/compose_validator.dart
+++ b/lib/src/validators/compose_validator.dart
@@ -15,7 +15,7 @@ class ComposeValidator extends Validator<dynamic> {
   /// Constructs an instance of the validator.
   ///
   /// The argument [validators] must not be null.
-  ComposeValidator(this.validators);
+  const ComposeValidator(this.validators);
 
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {

--- a/lib/src/validators/credit_card_validator.dart
+++ b/lib/src/validators/credit_card_validator.dart
@@ -8,6 +8,8 @@ import 'package:reactive_forms/src/validators/number_validator.dart';
 /// A credit card validator that validates that the control's value is a valid
 /// credit card.
 class CreditCardValidator extends Validator<dynamic> {
+  const CreditCardValidator();
+
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {
     final error = <String, dynamic>{ValidationMessage.creditCard: true};

--- a/lib/src/validators/email_validator.dart
+++ b/lib/src/validators/email_validator.dart
@@ -9,6 +9,8 @@ class EmailValidator extends Validator<dynamic> {
   static final RegExp emailRegex = RegExp(
       r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$');
 
+  const EmailValidator();
+
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {
     // don't validate empty values to allow optional controls

--- a/lib/src/validators/equals_validator.dart
+++ b/lib/src/validators/equals_validator.dart
@@ -16,7 +16,7 @@ class EqualsValidator<T> extends Validator<dynamic> {
   /// The argument [validationMessage] is optional and specify the key text for
   /// the validation error. I none value is supplied then the default value is
   /// [ValidationMessage.equals].
-  EqualsValidator(
+  const EqualsValidator(
     this.value, {
     this.validationMessage = ValidationMessage.equals,
   });

--- a/lib/src/validators/max_length_validator.dart
+++ b/lib/src/validators/max_length_validator.dart
@@ -12,7 +12,7 @@ class MaxLengthValidator extends Validator<dynamic> {
   /// Constructs a [MaxLengthValidator].
   ///
   /// The argument [maxLength] must not be null.
-  MaxLengthValidator(this.maxLength);
+  const MaxLengthValidator(this.maxLength);
 
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {

--- a/lib/src/validators/max_validator.dart
+++ b/lib/src/validators/max_validator.dart
@@ -12,7 +12,7 @@ class MaxValidator<T> extends Validator<dynamic> {
   /// Constructs the instance of the validator.
   ///
   /// The argument [max] must not be null.
-  MaxValidator(this.max);
+  const MaxValidator(this.max);
 
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {

--- a/lib/src/validators/min_length_validator.dart
+++ b/lib/src/validators/min_length_validator.dart
@@ -12,7 +12,7 @@ class MinLengthValidator extends Validator<dynamic> {
   /// Constructs a [MinLengthValidator].
   ///
   /// The argument [minLength] argument must not be null.
-  MinLengthValidator(this.minLength);
+  const MinLengthValidator(this.minLength);
 
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {

--- a/lib/src/validators/min_validator.dart
+++ b/lib/src/validators/min_validator.dart
@@ -12,7 +12,7 @@ class MinValidator<T> extends Validator<dynamic> {
   /// Constructs the instance of the validator.
   ///
   /// The argument [min] must not be null.
-  MinValidator(this.min);
+  const MinValidator(this.min);
 
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {

--- a/lib/src/validators/must_match_validator.dart
+++ b/lib/src/validators/must_match_validator.dart
@@ -12,7 +12,7 @@ class MustMatchValidator extends Validator<dynamic> {
   final bool markAsDirty;
 
   /// Constructs an instance of [MustMatchValidator]
-  MustMatchValidator(
+  const MustMatchValidator(
       this.controlName, this.matchingControlName, this.markAsDirty);
 
   @override

--- a/lib/src/validators/number_validator.dart
+++ b/lib/src/validators/number_validator.dart
@@ -6,6 +6,9 @@ import 'package:reactive_forms/reactive_forms.dart';
 
 /// Validator that validates if control's value is a numeric value.
 class NumberValidator extends Validator<dynamic> {
+  const NumberValidator();
+  
+
   /// The regex expression of a numeric string value.
   static final RegExp numberRegex = RegExp(r'^-?[0-9]+$');
 

--- a/lib/src/validators/pattern_validator.dart
+++ b/lib/src/validators/pattern_validator.dart
@@ -13,7 +13,7 @@ class PatternValidator extends Validator<dynamic> {
   /// Constructs an instance of [PatternValidator].
   ///
   /// The [evaluator] argument must not be null.
-  PatternValidator(this.evaluator,
+  const PatternValidator(this.evaluator,
       {this.validationMessage = ValidationMessage.pattern});
 
   @override

--- a/lib/src/validators/required_validator.dart
+++ b/lib/src/validators/required_validator.dart
@@ -6,6 +6,8 @@ import 'package:reactive_forms/reactive_forms.dart';
 
 /// Validator that requires the control have a non-empty value.
 class RequiredValidator extends Validator<dynamic> {
+  const RequiredValidator() : super();
+
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {
     final error = <String, dynamic>{ValidationMessage.required: true};

--- a/lib/src/validators/validator.dart
+++ b/lib/src/validators/validator.dart
@@ -6,5 +6,10 @@ import 'package:reactive_forms/reactive_forms.dart';
 
 /// An interface implemented by classes that perform synchronous validation.
 abstract class Validator<T> {
+  const Validator();
+
   Map<String, dynamic>? validate(AbstractControl<T> control);
+  Map<String, dynamic>? call(AbstractControl<T> control) {
+    return validate(control);
+  }
 }

--- a/lib/src/validators/validator.dart
+++ b/lib/src/validators/validator.dart
@@ -9,6 +9,7 @@ abstract class Validator<T> {
   const Validator();
 
   Map<String, dynamic>? validate(AbstractControl<T> control);
+
   Map<String, dynamic>? call(AbstractControl<T> control) {
     return validate(control);
   }

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -45,7 +45,7 @@ class Validators {
 
   /// Gets a validator that requires the control's value pass an email
   /// validation test.
-  static ValidatorFunction get email => EmailValidator().validate;
+  static const email = EmailValidator();
 
   /// Gets a validator that validates if control's value is a numeric value.
   static ValidatorFunction get number => NumberValidator().validate;

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -58,34 +58,33 @@ class Validators {
   /// argument [value].
   ///
   /// The argument [value] must not be null.
-  static ValidatorFunction equals<T>(T value) =>
-      EqualsValidator<T>(value).validate;
+  static ValidatorFunction equals<T>(T value) => EqualsValidator<T>(value);
 
   /// Gets a validator that requires the control's value to be greater than
   /// or equal to [min] value.
   ///
   /// The argument [min] must not be null.
-  static ValidatorFunction min<T>(T min) => MinValidator<T>(min).validate;
+  static ValidatorFunction min<T>(T min) => MinValidator<T>(min);
 
   /// Gets a validator that requires the control's value to be less than
   /// or equal to [max] value.
   ///
   /// The argument [max] must not be null.
-  static ValidatorFunction max<T>(T max) => MaxValidator<T>(max).validate;
+  static ValidatorFunction max<T>(T max) => MaxValidator<T>(max);
 
   /// Gets a validator that requires the length of the control's value to be
   /// greater than or equal to the provided [minLength].
   ///
   /// The argument [minLength] argument must not be null.
   static ValidatorFunction minLength(int minLength) =>
-      MinLengthValidator(minLength).validate;
+      MinLengthValidator(minLength);
 
   /// Gets a validator that requires the length of the control's value to be
   /// less than or equal to the provided [maxLength].
   ///
   /// The argument [maxLength] must not be null.
   static ValidatorFunction maxLength(int maxLength) =>
-      MaxLengthValidator(maxLength).validate;
+      MaxLengthValidator(maxLength);
 
   /// Gets a validator that requires the control's value to match a
   /// regex [pattern].
@@ -158,8 +157,7 @@ class Validators {
       evaluator = DefaultPatternEvaluator(pattern);
     }
 
-    return PatternValidator(evaluator, validationMessage: validationMessage)
-        .validate;
+    return PatternValidator(evaluator, validationMessage: validationMessage);
   }
 
   /// Gets a [FormGroup] validator that checks the controls [controlName] and
@@ -220,10 +218,11 @@ class Validators {
   /// ...
   /// ```
   static ValidatorFunction mustMatch(
-      String controlName, String matchingControlName,
-      {bool markAsDirty = true}) {
-    return MustMatchValidator(controlName, matchingControlName, markAsDirty)
-        .validate;
+    String controlName,
+    String matchingControlName, {
+    bool markAsDirty = true,
+  }) {
+    return MustMatchValidator(controlName, matchingControlName, markAsDirty);
   }
 
   /// Gets a [FormGroup] validator that compares two controls in the group.

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -36,7 +36,7 @@ typedef AsyncValidatorFunction = Future<Map<String, dynamic>?> Function(
 /// Provides a set of built-in validators that can be used by form controls.
 class Validators {
   /// Gets a validator that requires the control have a non-empty value.
-  static ValidatorFunction get required => RequiredValidator().validate;
+  static const required = RequiredValidator();
 
   /// Gets a validator that requires the control's value be true.
   /// This validator is commonly used for required checkboxes.

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -40,9 +40,8 @@ class Validators {
 
   /// Gets a validator that requires the control's value be true.
   /// This validator is commonly used for required checkboxes.
-  static ValidatorFunction get requiredTrue => EqualsValidator<bool>(true,
-          validationMessage: ValidationMessage.requiredTrue)
-      .validate;
+  static const requiredTrue = EqualsValidator<bool>(true,
+      validationMessage: ValidationMessage.requiredTrue);
 
   /// Gets a validator that requires the control's value pass an email
   /// validation test.

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -48,7 +48,7 @@ class Validators {
   static const email = EmailValidator();
 
   /// Gets a validator that validates if control's value is a numeric value.
-  static ValidatorFunction get number => NumberValidator().validate;
+  static const number = NumberValidator();
 
   /// Gets a validator that validates if the control's value is a valid
   /// credit card number.

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -52,7 +52,7 @@ class Validators {
 
   /// Gets a validator that validates if the control's value is a valid
   /// credit card number.
-  static ValidatorFunction get creditCard => CreditCardValidator().validate;
+  static const creditCard = CreditCardValidator();
 
   /// Gets a validator that requires the control's value to be equals to
   /// argument [value].

--- a/test/src/models/form_builder_test.dart
+++ b/test/src/models/form_builder_test.dart
@@ -109,7 +109,7 @@ void main() {
       // Expect a form group created
       expect(form.control('control') is FormControl<Object>, true,
           reason: 'control is not instance of FormControl<dynamic>');
-      expect(form.control('control').validators.first, validator,
+      expect(form.control('control').validators.first, validator.call,
           reason: 'validator not set');
     });
 
@@ -127,9 +127,9 @@ void main() {
           reason: 'control is not instance of FormControl<dynamic>');
       expect(form.control('control').validators.length, 2,
           reason: 'not set validators');
-      expect(form.control('control').validators[0], requiredValidator,
+      expect(form.control('control').validators[0], requiredValidator.call,
           reason: 'not set required validator');
-      expect(form.control('control').validators[1], emailValidator,
+      expect(form.control('control').validators[1], emailValidator.call,
           reason: 'not set email validator');
     });
 
@@ -181,7 +181,7 @@ void main() {
           reason: 'control is not instance of FormControl<String>');
       expect(form.control('control').value, '',
           reason: 'control default value not set');
-      expect(form.control('control').validators[0], requiredValidator,
+      expect(form.control('control').validators[0], requiredValidator.call,
           reason: 'not set required validator');
     });
 


### PR DESCRIPTION
## Connection with issue(s)

Close #375 

## Solution description

I just made all validator instance constructors constant, starting from the abstract class.

Another thing I've added is a `call` method to the abstract validator class to ensure it matches with the `ValidatorFunction` typedef.

## To Do

- [ ] Check if the solution works.
- [ ] Fix form group builder.
