### PR TITLE
Add RequiredNonEmptyValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ There are common predefined validators, but you can implement custom validators 
 #### FormControl
 
 - Validators.required
+- Validators.requiredNonEmpty
 - Validators.requiredTrue
 - Validators.email
 - Validators.number

--- a/lib/src/validators/required_non_empty_validator.dart
+++ b/lib/src/validators/required_non_empty_validator.dart
@@ -1,0 +1,28 @@
+// Copyright 2020 Joan Pablo Jimenez Milian. All rights reserved.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+import 'package:reactive_forms/reactive_forms.dart';
+
+/// Validator that requires the control's value to not be null or empty.
+class RequiredNonEmptyValidator extends Validator<dynamic> {
+  @override
+  Map<String, dynamic>? validate(AbstractControl<dynamic> control) {
+    final error = <String, dynamic>{ValidationMessage.requiredNonEmpty: true};
+    final dynamic value = control.value;
+
+    if (value == null) {
+      return error;
+    } else if (value is String) {
+      return value.trim().isEmpty ? error : null;
+    } else if (value is Iterable && value.isEmpty) {
+      return error;
+    } else if (value is Map && value.isEmpty) {
+      return error;
+    } else if (value is Set && value.isEmpty) {
+      return error;
+    }
+
+    return null;
+  }
+}

--- a/lib/src/validators/required_validator.dart
+++ b/lib/src/validators/required_validator.dart
@@ -4,7 +4,7 @@
 
 import 'package:reactive_forms/reactive_forms.dart';
 
-/// Validator that requires the control have a non-empty value.
+/// Validator that requires the control's value to not be null or blank string.
 class RequiredValidator extends Validator<dynamic> {
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {

--- a/lib/src/validators/validation_message.dart
+++ b/lib/src/validators/validation_message.dart
@@ -20,6 +20,9 @@ class ValidationMessage {
   /// Key text for required validation message.
   static const String required = 'required';
 
+  /// Key text for `requiredNonEmpty` validation message.
+  static const String requiredNonEmpty = 'requiredNonEmpty';
+
   /// Key text for pattern validation message.
   static const String pattern = 'pattern';
 

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -21,6 +21,7 @@ import 'package:reactive_forms/src/validators/pattern/default_pattern_evaluator.
 import 'package:reactive_forms/src/validators/pattern/pattern_evaluator.dart';
 import 'package:reactive_forms/src/validators/pattern/regex_pattern_evaluator.dart';
 import 'package:reactive_forms/src/validators/pattern_validator.dart';
+import 'package:reactive_forms/src/validators/required_non_empty_validator.dart';
 import 'package:reactive_forms/src/validators/required_validator.dart';
 
 /// Signature of a function that receives a control and synchronously
@@ -35,8 +36,15 @@ typedef AsyncValidatorFunction = Future<Map<String, dynamic>?> Function(
 
 /// Provides a set of built-in validators that can be used by form controls.
 class Validators {
-  /// Gets a validator that requires the control have a non-empty value.
+  /// Gets a validator that requires the control's value to not be null or
+  /// blank string.
   static ValidatorFunction get required => RequiredValidator().validate;
+
+  /// Gets a validator that requires the control's value be non-empty.
+  /// This validator is commonly used for fields that are both required and
+  /// should have a non-empty value.
+  static ValidatorFunction get requiredNonEmpty =>
+      RequiredNonEmptyValidator().validate;
 
   /// Gets a validator that requires the control's value be true.
   /// This validator is commonly used for required checkboxes.

--- a/test/src/validators/required_non_empty_validator_test.dart
+++ b/test/src/validators/required_non_empty_validator_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+void main() {
+  group('Required Non Empty validator tests', () {
+    test('FormControl is invalid if value is null', () {
+      // Given: an invalid control
+      final control = FormControl<dynamic>(
+        value: null,
+        validators: [Validators.requiredNonEmpty],
+      );
+
+      // Expect: control is invalid
+      expect(control.valid, false);
+      expect(control.errors, {ValidationMessage.requiredNonEmpty: true});
+    });
+
+    test('FormControl is valid if value is not null', () {
+      // Given: a valid control
+      final control = FormControl<num>(
+        value: 42,
+        validators: [Validators.requiredNonEmpty],
+      );
+
+      // Expect: control is valid
+      expect(control.valid, true);
+    });
+
+    test('FormControl is invalid if value is an emtpy list', () {
+      // Given: a valid control
+      final control = FormControl<List<dynamic>>(
+        value: <dynamic>[],
+        validators: [Validators.requiredNonEmpty],
+      );
+
+      // Expect: control is invalid
+      expect(control.valid, false);
+      expect(control.errors, {ValidationMessage.requiredNonEmpty: true});
+    });
+
+    test('FormControl is valid if value is non emtpy list', () {
+      // Given: a valid control
+      final control = FormControl<List<dynamic>>(
+        value: <dynamic>[1],
+        validators: [Validators.requiredNonEmpty],
+      );
+
+      // Expect: control is valid
+      expect(control.valid, true);
+    });
+  });
+}

--- a/test/src/validators/required_non_empty_validator_test.dart
+++ b/test/src/validators/required_non_empty_validator_test.dart
@@ -26,6 +26,41 @@ void main() {
       expect(control.valid, true);
     });
 
+    test('FormControl is invalid if string value is null', () {
+      // Given: an invalid control
+      final control = FormControl<String>(
+        value: null,
+        validators: [Validators.requiredNonEmpty],
+      );
+
+      // Expect: control is invalid
+      expect(control.valid, false);
+      expect(control.errors, {ValidationMessage.requiredNonEmpty: true});
+    });
+
+    test('FormControl is invalid if string value is empty', () {
+      // Given: an invalid control
+      final control = FormControl<String>(
+        value: " ",
+        validators: [Validators.requiredNonEmpty],
+      );
+
+      // Expect: control is invalid
+      expect(control.valid, false);
+      expect(control.errors, {ValidationMessage.requiredNonEmpty: true});
+    });
+
+    test('FormControl is valid if string value is not null', () {
+      // Given: a valid control
+      final control = FormControl<String>(
+        value: "42",
+        validators: [Validators.requiredNonEmpty],
+      );
+
+      // Expect: control is valid
+      expect(control.valid, true);
+    });
+
     test('FormControl is invalid if value is an emtpy list', () {
       // Given: a valid control
       final control = FormControl<List<dynamic>>(
@@ -42,6 +77,29 @@ void main() {
       // Given: a valid control
       final control = FormControl<List<dynamic>>(
         value: <dynamic>[1],
+        validators: [Validators.requiredNonEmpty],
+      );
+
+      // Expect: control is valid
+      expect(control.valid, true);
+    });
+
+    test('FormControl is invalid if value is an emtpy map', () {
+      // Given: a valid control
+      final control = FormControl<Map<String, dynamic>>(
+        value: <String, dynamic>{},
+        validators: [Validators.requiredNonEmpty],
+      );
+
+      // Expect: control is invalid
+      expect(control.valid, false);
+      expect(control.errors, {ValidationMessage.requiredNonEmpty: true});
+    });
+
+    test('FormControl is valid if value is non emtpy map', () {
+      // Given: a valid control
+      final control = FormControl<Map<String, dynamic>>(
+        value: <String, dynamic>{"answer": 42},
         validators: [Validators.requiredNonEmpty],
       );
 


### PR DESCRIPTION
## Connection with issue(s)

Close #377

## Solution description

Creates a separate `RequiredNonEmptyValidator` to cover cases of empty `Iterable`s ,`Map`s and `Set`s.

## Screenshots or Videos

## To Do

- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme