### PR TITLE
Allow FormBuilder to receive nullable AbstractControls

### DIFF
--- a/lib/src/models/form_builder.dart
+++ b/lib/src/models/form_builder.dart
@@ -78,7 +78,7 @@ class FormBuilder {
         return MapEntry(key, FormControl<DateTime>(value: value));
       } else if (value is TimeOfDay) {
         return MapEntry(key, FormControl<TimeOfDay>(value: value));
-      } else if (value is AbstractControl<Object>) {
+      } else if (value is AbstractControl<dynamic>) {
         return MapEntry(key, value);
       } else if (value is Validator<dynamic>) {
         return MapEntry(key, FormControl<dynamic>(validators: [value]));

--- a/test/src/models/form_builder_test.dart
+++ b/test/src/models/form_builder_test.dart
@@ -99,6 +99,18 @@ void main() {
           reason: 'control is not instance of FormControl<String>');
     });
 
+    test('Build a group with a nullable form control', () {
+      // Given: a form control with nullable type and a form group created with it
+      final control = fb.control<int?>(null);
+      final form = fb.group({
+        'control': control,
+      });
+
+      // Expect a form group created with the correct type
+      expect(form.control('control') is FormControl<int?>, true,
+          reason: 'control is not instance of FormControl<int?>');
+    });
+
     test('Build a group with single validator', () {
       // Given: a form group builder creation
       final validator = Validators.required;


### PR DESCRIPTION
`AbstractControl<Object>` didn't match AbstractControls with nullable types like AbstractControl<int?> causing it to skip to the last case where the control gets wrapped in another control. Now it behaves properly.

## Connection with issue(s)

none

## Solution description

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [ ] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme