### PR TITLE
fix: use intl 0.18.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.18.1
+  # flutter_localizations depends on intl 0.18.0
+  intl: ^0.18.0
 
 dev_dependencies:
   lints: ^2.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  # flutter_localizations depends on intl 0.18.0
-  intl: ^0.18.0
+  # when using flutter 3.10, flutter_localizations depends on intl 0.18.0
+  intl: ">=0.18.0 <1.0.0"
 
 dev_dependencies:
   lints: ^2.1.0


### PR DESCRIPTION
## Solution description

When a project use the built-in `flutter_localizations` package, an error occurs during the dependency retrieval process:
```
Resolving dependencies... (3.1s)
Because reactive_forms depends on flutter_localizations from sdk which depends on intl 0.18.0, intl 0.18.0 is required.
So, because reactive_forms depends on intl ^0.18.1, version solving failed.
```

So we should use intl 0.18.0.

## To Do

- [ ] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme