### PR TITLE
Add emitsCollectionChanged to FormGroup removeControl

### DIFF
--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -1569,6 +1569,8 @@ class FormGroup extends FormControlCollection<Map<String, Object?>> {
 
     _controls.removeWhere((key, value) => key == name);
     updateValueAndValidity(updateParent: updateParent, emitEvent: emitEvent);
+
+    emitsCollectionChanged(_controls.values.toList());
   }
 
   @override


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #399

## Solution description
After little digging I've discovered that after remove control from controls list, removeControl doesn't calling emitsCollectionChanged so I've added it. If you want I can add tests for collectionChange cause I've discovered that  it isn't tested yet. But it will take some times, because I have a lot of work(probably 1-2 weeks, so it's could be done in next pull request). Additionaly I'm not sure, should I wrap it with  
```dart
 if (emitEvent) {
      ...
    }
```
If so, please let me know and I'll change it

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme