### PR TITLE
Updated must_match_validator.dart

### DIFF
--- a/lib/src/validators/must_match_validator.dart
+++ b/lib/src/validators/must_match_validator.dart
@@ -17,17 +17,19 @@ class MustMatchValidator extends Validator<dynamic> {
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {
     final error = {ValidationMessage.mustMatch: true};
-    var form = {};
+    var form = <dynamic, dynamic>{};
     control.parent?.valueChanges.listen((event) {
-      form = event as Map<dynamic, dynamic>;
-
-      if (form[controlName] != form[matchingControlName]) {
-        control.setErrors(error, markAsDirty: markAsDirty);
-        control.markAsTouched();
-      } else {
-        control.removeError(ValidationMessage.mustMatch);
+      if (event != null) {
+        form = event as Map;
+        if (form[controlName] != form[matchingControlName]) {
+          control.setErrors(error, markAsDirty: markAsDirty);
+          control.markAsTouched();
+        } else {
+          control.removeError(ValidationMessage.mustMatch);
+        }
       }
     });
+
     return null;
   }
 }

--- a/lib/src/validators/must_match_validator.dart
+++ b/lib/src/validators/must_match_validator.dart
@@ -10,8 +10,6 @@ class MustMatchValidator extends Validator<dynamic> {
   final String controlName;
   final String matchingControlName;
   final bool markAsDirty;
-
-  /// Constructs an instance of [MustMatchValidator]
   const MustMatchValidator(
       this.controlName, this.matchingControlName, this.markAsDirty)
       : super();
@@ -19,21 +17,17 @@ class MustMatchValidator extends Validator<dynamic> {
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {
     final error = {ValidationMessage.mustMatch: true};
+    var form = {};
+    control.parent?.valueChanges.listen((event) {
+      form = event as Map<dynamic, dynamic>;
 
-    if (control is! FormGroup) {
-      return error;
-    }
-
-    final formControl = control.control(controlName);
-    final matchingFormControl = control.control(matchingControlName);
-
-    if (formControl.value != matchingFormControl.value) {
-      matchingFormControl.setErrors(error, markAsDirty: markAsDirty);
-      matchingFormControl.markAsTouched();
-    } else {
-      matchingFormControl.removeError(ValidationMessage.mustMatch);
-    }
-
+      if (form[controlName] != form[matchingControlName]) {
+        control.setErrors(error, markAsDirty: markAsDirty);
+        control.markAsTouched();
+      } else {
+        control.removeError(ValidationMessage.mustMatch);
+      }
+    });
     return null;
   }
 }

--- a/lib/src/validators/must_match_validator.dart
+++ b/lib/src/validators/must_match_validator.dart
@@ -16,20 +16,23 @@ class MustMatchValidator extends Validator<dynamic> {
 
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {
-    final error = {ValidationMessage.mustMatch: true};
-    var form = <dynamic, dynamic>{};
-    control.parent?.valueChanges.listen((event) {
-      if (event != null) {
-        form = event as Map;
-        if (form[controlName] != form[matchingControlName]) {
-          control.setErrors(error, markAsDirty: markAsDirty);
-          control.markAsTouched();
-        } else {
-          control.removeError(ValidationMessage.mustMatch);
+    try {
+      final error = {ValidationMessage.mustMatch: true};
+      var form = <dynamic, dynamic>{};
+      control.parent?.valueChanges.listen((event) {
+        if (event != null) {
+          form = event as Map;
+          if (form[controlName] != form[matchingControlName]) {
+            control.setErrors(error, markAsDirty: markAsDirty);
+            control.markAsTouched();
+          } else {
+            control.removeError(ValidationMessage.mustMatch);
+          }
         }
-      }
-    });
-
+      });
+    } catch (e) {
+      return null;
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #???

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #???
https://github.com/joanpablo/reactive_forms/issues/404

## Solution description
Modified built-in must_match_validator.dart. 
- Implemented control parent value listener to check if both fields have the same value.
- Works with reactive_forms_generator & freezed

## Screenshots or Videos
![image](https://github.com/joanpablo/reactive_forms/assets/48149031/a1fbb4c3-745b-465f-8357-5692e5948c24)

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [ ] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme