### PR TITLE
Fix missing context menu in ReactiveTextField

### DIFF
--- a/lib/src/widgets/reactive_text_field.dart
+++ b/lib/src/widgets/reactive_text_field.dart
@@ -101,7 +101,8 @@ class ReactiveTextField<T> extends ReactiveFormField<T, String> {
     TextAlignVertical? textAlignVertical,
     bool autofocus = false,
     bool readOnly = false,
-    EditableTextContextMenuBuilder? contextMenuBuilder,
+    EditableTextContextMenuBuilder? contextMenuBuilder =
+        _defaultContextMenuBuilder,
     bool? showCursor,
     bool obscureText = false,
     String obscuringCharacter = '•',
@@ -240,6 +241,13 @@ class ReactiveTextField<T> extends ReactiveFormField<T, String> {
             );
           },
         );
+
+  static Widget _defaultContextMenuBuilder(
+      BuildContext context, EditableTextState editableTextState) {
+    return AdaptiveTextSelectionToolbar.editableText(
+      editableTextState: editableTextState,
+    );
+  }
 
   @override
   ReactiveFormFieldState<T, String> createState() =>


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #398

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Solution description

copied the default _defaultContextMenuBuilder from vanilla Flutter TextField to ReactiveTextField to keep the same behaviour

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [ ] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme