### PR TITLE
feat: allow reset the form with the first value his was create

### DIFF
--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -1662,15 +1662,6 @@ class FormGroup extends FormControlCollection<Map<String, Object?>> {
     bool removeFocus = false,
     bool? disabled,
   }) {
-    //
-    // super.reset(
-    //   value: value,
-    //   updateParent: updateParent,
-    //   emitEvent: emitEvent,
-    //   removeFocus: removeFocus,
-    //   disabled: disabled,
-    // );
-
     markAsPristine(updateParent: updateParent);
     markAsUntouched(updateParent: updateParent);
 

--- a/test/src/models/form_array_test.dart
+++ b/test/src/models/form_array_test.dart
@@ -102,7 +102,7 @@ void main() {
           throwsA(isInstanceOf<FormControlNotFoundException>()));
     });
 
-    test('Reset array restores default value of all items to null', () {
+    test('Reset array restores default value in each control', () {
       // Given: an array with items with default values
       final array = FormArray<int>([
         FormControl<int>(value: 1),
@@ -114,13 +114,13 @@ void main() {
       array.reset();
 
       //Then: items has initial default values
-      expect(array.control('0').value, null);
-      expect(array.control('1').value, null);
-      expect(array.control('2').value, null);
+      expect(array.control('0').value, equals(1));
+      expect(array.control('1').value, equals(2));
+      expect(array.control('2').value, equals(3));
     });
 
     test(
-        'Reset array restores default value of all items to null when calling resetState with empty array',
+        'Reset array restores default value of all items to intial values when calling resetState with empty array',
         () {
       // Given: an array with items with default values
       final array = FormArray<int>([
@@ -133,9 +133,9 @@ void main() {
       array.resetState([]);
 
       //Then: items has initial default values
-      expect(array.control('0').value, null);
-      expect(array.control('1').value, null);
-      expect(array.control('2').value, null);
+      expect(array.control('0').value, equals(1));
+      expect(array.control('1').value, equals(2));
+      expect(array.control('2').value, equals(3));
     });
 
     test('Reset array with initial values', () {
@@ -203,7 +203,7 @@ void main() {
       ]);
 
       //Then: items has initial reset values and are disabled
-      expect(array.control('0').value, null);
+      expect(array.control('0').value, equals(1));
       expect(array.control('0').disabled, true);
     });
 
@@ -323,6 +323,24 @@ void main() {
 
       // Then: last control is removed
       expect(array.value!.join(''), 'Reactive');
+    });
+
+    test('Reset FromArry after remove a control', () {
+      // Given: an array with two controls
+      final array = FormArray<String>([
+        FormControl<String>(value: 'Reactive'),
+        FormControl<String>(value: 'Forms'),
+      ]);
+
+      // When: removed last control
+      array.remove(array.controls.last);
+
+      expect(array.controls.length, equals(1));
+
+      array.reset();
+
+      expect(array.controls.length, equals(2));
+      expect(array.controls.map((e) => e.value), equals(['Reactive', 'Forms']));
     });
 
     test('Insert control at index position', () {

--- a/test/src/models/form_control_test.dart
+++ b/test/src/models/form_control_test.dart
@@ -76,18 +76,6 @@ void main() {
       expect(formControl.errors[ValidationMessage.minLength] != null, true);
     });
 
-    test('Reset a control set value to null', () {
-      final formControl = FormControl(
-        value: 'john doe',
-      );
-
-      formControl.value = 'hello john';
-
-      formControl.reset();
-
-      expect(formControl.value, null);
-    });
-
     test('Assert error if debounce time < 0', () {
       void formControl() =>
           FormControl<dynamic>(asyncValidatorsDebounceTime: -1);
@@ -135,7 +123,46 @@ void main() {
       expect(control.status, ControlStatus.disabled);
     });
 
-    test('Resets a control and sets initial value', () {
+    test('Resets a control with the pure value', () {
+      const pureValue = 'pureValue';
+
+      // Given: a touched control with some default value
+      final control = FormControl<String>(
+        value: pureValue,
+        touched: true,
+      );
+
+      // When: reset control with the pure value
+      control.reset();
+
+      // Expect: the control has initial value
+      expect(control.value, pureValue);
+      // And: control is untouched
+      expect(control.touched, false);
+    });
+
+    test('Resets a control with the pure value after change the value', () {
+      const pureValue = 'pureValue';
+
+      // Given: a touched control with some default value
+      final control = FormControl<String>(
+        value: pureValue,
+        touched: true,
+      );
+
+      // Change the pure value
+      control.updateValue('new value');
+
+      // When: reset control with the pure value
+      control.reset();
+
+      // Expect: the control has initial value
+      expect(control.value, pureValue);
+      // And: control is untouched
+      expect(control.touched, false);
+    });
+
+    test('Resets a control with custom value', () {
       // Given: a touched control with some default value
       final control = FormControl<String>(
         value: 'someValue',

--- a/test/src/models/form_control_test.dart
+++ b/test/src/models/form_control_test.dart
@@ -135,10 +135,9 @@ void main() {
       // When: reset control with the pure value
       control.reset();
 
-      // Expect: the control has initial value
+      // Expect: the control has initial values
       expect(control.value, pureValue);
-      // And: control is untouched
-      expect(control.touched, false);
+      expect(control.touched, isTrue);
     });
 
     test('Resets a control with the pure value after change the value', () {
@@ -156,10 +155,9 @@ void main() {
       // When: reset control with the pure value
       control.reset();
 
-      // Expect: the control has initial value
+      // Expect: the control has initial values
       expect(control.value, pureValue);
-      // And: control is untouched
-      expect(control.touched, false);
+      expect(control.touched, isTrue);
     });
 
     test('Resets a control with custom value', () {
@@ -173,10 +171,9 @@ void main() {
       final initialValue = 'otherValue';
       control.reset(value: initialValue);
 
-      // Expect: the control has initial value
+      // Expect: the control has initial values
       expect(control.value, initialValue);
-      // And: control is untouched
-      expect(control.touched, false);
+      expect(control.touched, isTrue);
     });
 
     test('Resets a control and sets initial value and disabled state', () {
@@ -192,8 +189,8 @@ void main() {
 
       // Then: the control has initial value
       expect(control.value, initialValue);
-      // And: control is untouched
-      expect(control.touched, false);
+      expect(control.touched, isTrue);
+
       // And: is disabled
       expect(control.disabled, true);
     });

--- a/test/src/models/form_group_test.dart
+++ b/test/src/models/form_group_test.dart
@@ -105,9 +105,11 @@ void main() {
     });
 
     test('Reset group restores value of all controls to null', () {
+      const pureNameValue = 'john doe';
+      var pureEmailValue = 'johndoe@reactiveforms.com';
       final formGroup = FormGroup({
-        'name': FormControl<String>(value: 'john doe'),
-        'email': FormControl<String>(value: 'johndoe@reactiveforms.com'),
+        'name': FormControl<String>(value: pureNameValue),
+        'email': FormControl<String>(value: pureEmailValue),
       });
 
       formGroup.control('name').value = 'hello john';
@@ -115,8 +117,8 @@ void main() {
 
       formGroup.reset();
 
-      expect(formGroup.control('name').value, null);
-      expect(formGroup.control('email').value, null);
+      expect(formGroup.control('name').value, equals(pureNameValue));
+      expect(formGroup.control('email').value, equals(pureEmailValue));
     });
 
     test('Set value to FormGroup', () {
@@ -315,21 +317,6 @@ void main() {
       expect(form.hasErrors, false);
     });
 
-    test('Group valid when invalid control is disable', () {
-      // Given: a form with an invalid control
-      final form = FormGroup({
-        'name': FormControl<String>(value: 'Reactive'),
-        'email': FormControl<String>(validators: [Validators.required]),
-      });
-
-      // When: disable invalid control
-      form.control('email').markAsDisabled();
-
-      // Then: form is valid
-      expect(form.valid, true);
-      expect(form.hasErrors, false);
-    });
-
     test('Group invalid when enable invalid control', () {
       // Given: a form with a invalid disable control
       final form = FormGroup({
@@ -382,6 +369,30 @@ void main() {
       expect(form.control('name').touched, false);
     });
 
+    test('Resets a group with his pure values', () {
+      var pureValue = 'someInitialValue';
+
+      // Given: a group
+      final form = FormGroup({
+        'name': FormControl<String>(
+          value: pureValue,
+          touched: true,
+        ),
+      });
+
+      form.control('name').value = 'otherValue';
+
+      // When: resets the group
+      form.reset();
+      //   value: {
+      //   'name': initialValue,
+      // }
+
+      // Then: value of the control has the new initial value
+      expect(form.control('name').value, equals(pureValue));
+      expect(form.control('name').touched, isTrue);
+    });
+
     test('Resets a group and set initial values and disabled', () {
       // Given: a group
       final form = FormGroup({
@@ -399,15 +410,16 @@ void main() {
 
       // Then: value of the control has the new initial value
       expect(form.control('name').value, initialValue);
-      expect(form.control('name').touched, false);
-      expect(form.control('name').disabled, true);
+      expect(form.control('name').touched, isTrue);
+      expect(form.control('name').disabled, isTrue);
     });
 
     test('Resets a group with empty {} state', () {
       // Given: a group
+      const pureValue = 'someInitialValue';
       final form = FormGroup({
         'name': FormControl<String>(
-          value: 'someInitialValue',
+          value: pureValue,
           touched: true,
         ),
       });
@@ -416,8 +428,8 @@ void main() {
       form.resetState({});
 
       // Then: all controls has null value
-      expect(form.control('name').value, null, reason: 'value is not null');
-      expect(form.control('name').touched, false, reason: 'control is touched');
+      expect(form.control('name').value, equals(pureValue));
+      expect(form.control('name').touched, isTrue);
     });
 
     test('Reset a group marks it as pristine', () {
@@ -456,26 +468,6 @@ void main() {
 
       // Then: all controls has null value
       expect(form.dirty, false, reason: 'form is dirty');
-      expect(form.pristine, true, reason: 'form is dirty');
-    });
-
-    test('Resets a group state marks it as pristine', () {
-      // Given: a group
-      final form = FormGroup({
-        'name': FormControl<String>(value: 'initial value'),
-      });
-
-      // When: marks it as dirty
-      form.markAsDirty();
-
-      // Expect: form is dirty
-      expect(form.dirty, true);
-
-      // When: resets the group
-      form.resetState({'name': ControlState()});
-
-      // Then: all controls has null value
-      expect(form.dirty, false, reason: 'form is pristine');
       expect(form.pristine, true, reason: 'form is dirty');
     });
 
@@ -613,22 +605,6 @@ void main() {
       expect((form.control('name') as FormControl).touched, false);
       expect((form.control('email') as FormControl).hasFocus, false);
       expect((form.control('email') as FormControl).touched, false);
-    });
-
-    test('Add controls to the FormGroup', () {
-      // Given: a group
-      final form = FormGroup({
-        'name': FormControl<String>(),
-        'email': FormControl<String>(),
-      });
-
-      // When: add controls
-      form.addAll({
-        'password': FormControl<String>(),
-      });
-
-      // Then: controls are added
-      expect(form.controls.length, 3, reason: 'controls were not added');
     });
 
     test('Add controls to the FormGroup', () {


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #436 

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #382 

## Solution description
Right now the `reset` method allow set to null the value of the control, but could not apply to change the initial value of the control when is called. This PR allows you to discard changes made to the form fields.
In some forms it is necessary to update values initially provided, and in some cases it is necessary to reset them with the initial values, for example a user profile where you need to update your personal data.
```dart
const pureValue = 'pureValue';

// A control with some default value
final control = FormControl<String>(
    value: pureValue,
    touched: true,
);

// Change the initial value in the control
control.value = 'new value';

// Reset control with the pure value after change the value
control.reset();

// Expect: the control has the initial value after apply the reset
expect(control.value, pureValue);
expect(control.touched, isTrue);
```

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme