### PR TITLE
Reduce intl constraint to match flutter_localizations 3.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 17.0.0+1
+
+- Reduce `intl` dependency constraint to match Flutter 3.16.0
+
 # 17.0.0
 
 ## Breaking changes

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.19.0
+  flutter_localizations:
+    sdk: flutter
+  intl: '>=0.18.1 <1.0.0'
   reactive_forms:
     path: ../
   #reactive_forms_widgets: ^0.3.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_forms
 description: This is a model-driven approach to handling form inputs and validations, heavily inspired in Angular Reactive Forms.
-version: 17.0.0
+version: 17.0.0+1
 homepage: "https://github.com/joanpablo/reactive_forms"
 
 environment:
@@ -10,7 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ">=0.19.0 <1.0.0"
+  # Keep flutter_localizations to ensure correct intl constraints
+  flutter_localizations:
+    sdk: flutter
+  intl: ">=0.18.1 <1.0.0"
 
 dev_dependencies:
   flutter_lints: ^3.0.2


### PR DESCRIPTION
## Connection with issue(s)

See https://github.com/joanpablo/reactive_forms/commit/839968f596058c5466b61fd37a2dde56f03b4e29#r141272235

The `flutter_localizations` package from Flutter SDK 3.16.0 forces `intl: 0.18.1` - see https://github.com/flutter/flutter/blob/3.16.0/packages/flutter_localizations/pubspec.yaml#L11

## Solution description

I reduced the constraint and added the `flutter_localizations` package as additional dependency to ensure this does not happen again. This should have no impact on consumers of the package as the Flutter SDK is already required.


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme