### PR TITLE
Added getter errorMessages to reactive_form_field.dart

### DIFF
--- a/lib/src/widgets/reactive_form_field.dart
+++ b/lib/src/widgets/reactive_form_field.dart
@@ -119,6 +119,43 @@ class ReactiveFormFieldState<ModelDataType, ViewDataType>
     return null;
   }
 
+  /// Gets a list of error messages associated with the [FormControl] bound to this widget.
+  ///
+  /// If the control has errors and the `_showErrors` flag is true, this getter will return a list of error messages.
+  /// The error messages are determined based on the keys in the `control.errors` map.
+  ///
+  /// If the 'required' error is present, it will return a list containing only the 'required' error message.
+  /// The error message is either a custom validation message for 'required' error, if provided, or the string 'required'.
+  ///
+  /// If the 'required' error is not present, it will return a list of all other error messages.
+  /// For each error key, it will try to find a custom validation message. If a custom validation message is found,
+  /// it will be used as the error message. Otherwise, the error key itself will be used as the error message.
+  ///
+  /// If the control has no errors or the `_showErrors` flag is false, it will return an empty list.
+  List<String> get errorMessages {
+    if (control.hasErrors && _showErrors) {
+      // Check if 'required' error is present
+      if (control.errors.containsKey('required')) {
+        final validationMessage = _findValidationMessage('required');
+        return [
+          validationMessage != null
+              ? validationMessage(control.getError('required')!)
+              : 'required',
+        ];
+      }
+
+      // If 'required' error is not present, return all other error messages
+      return control.errors.keys.map((errorKey) {
+        final validationMessage = _findValidationMessage(errorKey);
+        return validationMessage != null
+            ? validationMessage(control.getError(errorKey)!)
+            : errorKey;
+      }).toList();
+    }
+
+    return [];
+  }
+
   bool get _showErrors {
     if (widget.showErrors != null) {
       return widget.showErrors!(control);


### PR DESCRIPTION
# Added getter errorMessages to reactive_form_field.dart
## Connection with Issues
- Close Issue: This pull request addresses and resolves issue #454.

## Solution Description

The errorMessages getter has been implemented to retrieve a list of all error messages (in addition to the errorText getter, which only returns the first) associated with the FormControl bound to the widget. Here’s a detailed breakdown of the solution:

- Error Condition: The getter checks if the control has errors and if the _showErrors flag is true.
- If the 'required' error is present, the method returns a list containing the 'required' error message.
- The error message is either a custom validation message (if provided) or the string 'required'.

Handling Other Errors:
- If the 'required' error is not present, the method returns a list of all other error messages.
- For each error key, it looks for a custom validation message.
- If a custom validation message is found, it is used as the error message. Otherwise, the error key itself is used as the error message.
- No Errors or Flag False: If the control has no errors or the _showErrors flag is false, an empty list is returned.

## Result
This getter provides more extensive customization options for custom `ReactiveTextFields`.