### PR TITLE
MustMatchValidator validator, optional markAsTouched

### DIFF
--- a/lib/src/validators/must_match_validator.dart
+++ b/lib/src/validators/must_match_validator.dart
@@ -10,10 +10,12 @@ class MustMatchValidator extends Validator<dynamic> {
   final String controlName;
   final String matchingControlName;
   final bool markAsDirty;
+  final bool markAsTouched;
 
   /// Constructs an instance of [MustMatchValidator]
   const MustMatchValidator(
-      this.controlName, this.matchingControlName, this.markAsDirty)
+      this.controlName, this.matchingControlName, this.markAsDirty,
+      {this.markAsTouched = true})
       : super();
 
   @override
@@ -29,7 +31,9 @@ class MustMatchValidator extends Validator<dynamic> {
 
     if (formControl.value != matchingFormControl.value) {
       matchingFormControl.setErrors(error, markAsDirty: markAsDirty);
-      matchingFormControl.markAsTouched();
+      if (markAsTouched) {
+        matchingFormControl.markAsTouched();
+      }
     } else {
       matchingFormControl.removeError(ValidationMessage.mustMatch);
     }

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -216,8 +216,9 @@ class Validators {
   /// ```
   static Validator<dynamic> mustMatch(
       String controlName, String matchingControlName,
-      {bool markAsDirty = true}) {
-    return MustMatchValidator(controlName, matchingControlName, markAsDirty);
+      {bool markAsDirty = true, bool markAsTouched = true}) {
+    return MustMatchValidator(controlName, matchingControlName, markAsDirty,
+        markAsTouched: markAsTouched);
   }
 
   /// Creates a [FormGroup] validator that compares two controls in the group.

--- a/lib/src/widgets/reactive_form_field.dart
+++ b/lib/src/widgets/reactive_form_field.dart
@@ -119,6 +119,43 @@ class ReactiveFormFieldState<ModelDataType, ViewDataType>
     return null;
   }
 
+  /// Gets a list of error messages associated with the [FormControl] bound to this widget.
+  ///
+  /// If the control has errors and the `_showErrors` flag is true, this getter will return a list of error messages.
+  /// The error messages are determined based on the keys in the `control.errors` map.
+  ///
+  /// If the 'required' error is present, it will return a list containing only the 'required' error message.
+  /// The error message is either a custom validation message for 'required' error, if provided, or the string 'required'.
+  ///
+  /// If the 'required' error is not present, it will return a list of all other error messages.
+  /// For each error key, it will try to find a custom validation message. If a custom validation message is found,
+  /// it will be used as the error message. Otherwise, the error key itself will be used as the error message.
+  ///
+  /// If the control has no errors or the `_showErrors` flag is false, it will return an empty list.
+  List<String> get errorMessages {
+    if (control.hasErrors && _showErrors) {
+      // Check if 'required' error is present
+      if (control.errors.containsKey('required')) {
+        final validationMessage = _findValidationMessage('required');
+        return [
+          validationMessage != null
+              ? validationMessage(control.getError('required')!)
+              : 'required',
+        ];
+      }
+
+      // If 'required' error is not present, return all other error messages
+      return control.errors.keys.map((errorKey) {
+        final validationMessage = _findValidationMessage(errorKey);
+        return validationMessage != null
+            ? validationMessage(control.getError(errorKey)!)
+            : errorKey;
+      }).toList();
+    }
+
+    return [];
+  }
+
   bool get _showErrors {
     if (widget.showErrors != null) {
       return widget.showErrors!(control);


### PR DESCRIPTION
## Connection with Issues
- None

## Solution Description

The markAsTouched variable inside the mustMatch validator has been made optional. The changes were implemented in both the MustMatchValidator class and the mustMatch validator inside the validators.dart file.

### Breakdown of changes:

- Optional markAsTouched: The markAsTouched parameter is now optional, with a default value of true (resulting in no changes in current behavior).
- Updated Constructor: The constructor of the MustMatchValidator class has been updated to reflect the optional markAsTouched parameter.
- Validator Function: The mustMatch validator function in validators.dart has been updated to pass the optional markAsTouched parameter.