### PR TITLE
Fix: const constructors for PatternEvaluators

### DIFF
--- a/lib/src/validators/pattern/default_pattern_evaluator.dart
+++ b/lib/src/validators/pattern/default_pattern_evaluator.dart
@@ -6,7 +6,7 @@ class DefaultPatternEvaluator implements PatternEvaluator {
 
   /// Constructs an instance of the class.
   /// The argument [pattern] must not be null.
-  DefaultPatternEvaluator(Pattern pattern) : _pattern = pattern;
+  const DefaultPatternEvaluator(Pattern pattern) : _pattern = pattern;
 
   @override
   bool hasMatch(String input) => _pattern.allMatches(input).isNotEmpty;

--- a/lib/src/validators/pattern/regex_pattern_evaluator.dart
+++ b/lib/src/validators/pattern/regex_pattern_evaluator.dart
@@ -6,7 +6,7 @@ class RegExpPatternEvaluator implements PatternEvaluator {
 
   /// Constructs an instance of the class.
   /// The argument [regExp] must not be null.
-  RegExpPatternEvaluator(this.regExp);
+  const RegExpPatternEvaluator(this.regExp);
 
   @override
   bool hasMatch(String input) {


### PR DESCRIPTION
I've added `const` keyword in two places.

This change is needed to allow us to use `PatternEvaluator`s with code generation version of this plugin like this:

```dart
@RfControl(validators: [
      RequiredValidator(),
      PatternValidator(
        DefaultPatternEvaluator(
          r'^(https:\/\/)[a-zA-Z0-9\-\.]+\.[a-z]{2,3}(/\S*)?$',
        ),
      )
    ])
    String? url,
```