### PR TITLE
feat: support controlFactory in both FormGroup and FormArray

### DIFF
--- a/lib/src/models/form_builder.dart
+++ b/lib/src/models/form_builder.dart
@@ -63,6 +63,7 @@ class FormBuilder {
     Map<String, Object> controls, [
     List<Validator<dynamic>> validators = const [],
     List<AsyncValidator<dynamic>> asyncValidators = const [],
+    FormGroupControlFactory? controlFactory,
   ]) {
     final map = controls
         .map<String, AbstractControl<dynamic>>((String key, Object value) {
@@ -117,6 +118,7 @@ class FormBuilder {
       map,
       validators: validators,
       asyncValidators: asyncValidators,
+      controlFactory: controlFactory,
     );
   }
 
@@ -203,6 +205,7 @@ class FormBuilder {
     List<Object> value, [
     List<Validator<dynamic>> validators = const [],
     List<AsyncValidator<dynamic>> asyncValidators = const [],
+    FormArrayControlFactory<T>? controlFactory,
   ]) {
     return FormArray<T>(
       value.map<AbstractControl<T>>((v) {
@@ -217,6 +220,7 @@ class FormBuilder {
       }).toList(),
       validators: validators,
       asyncValidators: asyncValidators,
+      controlFactory: controlFactory,
     );
   }
 

--- a/test/src/models/form_array_test.dart
+++ b/test/src/models/form_array_test.dart
@@ -735,6 +735,51 @@ void main() {
       // Then: the status of the array is PENDING as well.
       expect(array.pending, true);
     });
+
+    test(
+      'Test controlFactory',
+      () {
+        // Given: a FormArray with a controlFactory
+
+        final array = FormArray<Map<String, Object?>>(
+          [
+            FormControl(value: {}),
+            FormGroup({
+              'key': FormControl<int>(),
+            }),
+          ],
+          controlFactory: (index, value) {
+            return FormGroup(
+              {},
+              controlFactory: (key, value) =>
+                  FormControl<bool>(value: value as bool?),
+            )..value = value;
+          },
+        );
+
+        // When: calling updateValue
+        array.updateValue([
+          {'key': 'value1'},
+          {'key': 20},
+          {'key': true},
+        ]);
+
+        // Then: missing controls are created
+        expect(array.controls.length, 3);
+        expect(
+          (array.control('0').value as Map<String, Object?>)['key'],
+          'value1',
+        );
+        expect(
+          array.control('1.key').value,
+          20,
+        );
+        expect(
+          array.control('2.key').value,
+          true,
+        );
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Connection with issue(s)

Close #366 
Connected to #154

## Solution description

This adds a new optional `controlFactory` parameter to both `FormGroup` and `FormArray`.

its only responsibility is creating new controls when calling `updateValue`

for a usage example see the test

## To Do

- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme