### PR TITLE
Feat/form control reset initial value

### DIFF
--- a/.github/workflows/reactive_forms.yaml
+++ b/.github/workflows/reactive_forms.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.0"
+          flutter-version: "3.29.0"
           channel: "stable"
       - run: flutter pub get
       - run: flutter test --no-pub --coverage
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.0"
+          flutter-version: "3.29.0"
           channel: "stable"
       - run: flutter pub get
       - name: Analyze lib
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.0"
+          flutter-version: "3.29.0"
           channel: "stable"
       - run: flutter pub get
       - name: Format lib
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.27.0"
+          flutter-version: "3.29.0"
           channel: "stable"
       - run: flutter pub get
       - name: Check publish warnings
@@ -82,7 +82,7 @@ jobs:
     - name: Download flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: "3.27.0"
+        flutter-version: "3.29.0"
         channel: "stable"
     - name: Setup pub credentials
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # 18.0.1
 
-- Downgraded Flutter version to `3.27.0` and SDK to `^3.6.0`.
-  This is due to an issue reported in dart-lang: https://github.com/dart-lang/sdk/issues/60335.
+## Features
+- The FormControl.reset() method has been updated to align with
+  the common expectation that resetting a control without specifying a
+  new value should revert it to its initial state.
 
 ## Fixes
 - Fixed broken reactivity with the `PopScope`.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ samples, guidance on mobile development, and a full API reference.
 
 ## Minimum Requirements
 
-- Dart SDK: ^3.6.0
-- Flutter: ">=3.27.0"
+- Dart SDK: ^3.7.0
+- Flutter: ">=3.29.0"
 
 > For using **Reactive Forms** in projects below Flutter 2.8.0 please use the version <= 10.7.0 of
 > **Reactive Forms**.

--- a/lib/src/models/focus_controller.dart
+++ b/lib/src/models/focus_controller.dart
@@ -20,8 +20,8 @@ class FocusController extends ChangeNotifier {
   /// it and [focusNode] must be explicitly dispose after dispose focus
   /// controller instance.
   FocusController({FocusNode? focusNode})
-      : _focusNode = focusNode ?? FocusNode(),
-        _shouldDisposeFocusNode = focusNode == null {
+    : _focusNode = focusNode ?? FocusNode(),
+      _shouldDisposeFocusNode = focusNode == null {
     this.focusNode.addListener(_onFocusNodeFocusChanges);
   }
 

--- a/lib/src/models/form_builder.dart
+++ b/lib/src/models/form_builder.dart
@@ -106,9 +106,10 @@ class FormBuilder {
             );
           }
 
-          final effectiveValidators = validators
-              .map<Validator<dynamic>>((v) => v! as Validator<dynamic>)
-              .toList();
+          final effectiveValidators =
+              validators
+                  .map<Validator<dynamic>>((v) => v! as Validator<dynamic>)
+                  .toList();
 
           return MapEntry(key, _control(defaultValue, effectiveValidators));
         }

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -797,6 +797,7 @@ abstract class AbstractControl<T> {
 
 /// Tracks the value and validation status of an individual form control.
 class FormControl<T> extends AbstractControl<T> {
+  final T? _initialValue;
   final _focusChanges = StreamController<bool>.broadcast();
   FocusController? _focusController;
   bool _hasFocus = false;
@@ -838,7 +839,7 @@ class FormControl<T> extends AbstractControl<T> {
     super.asyncValidatorsDebounceTime,
     super.touched,
     super.disabled,
-  }) {
+  }) : _initialValue = value {
     if (value != null) {
       this.value = value;
     } else {
@@ -965,6 +966,28 @@ class FormControl<T> extends AbstractControl<T> {
     if (notifyFocusController) {
       _focusController?.onControlFocusChanged(_hasFocus);
     }
+  }
+
+  @override
+  void reset({
+    T? value,
+    bool updateParent = true,
+    bool emitEvent = true,
+    bool removeFocus = false,
+    bool? disabled,
+  }) {
+    // If `value` is null, it implies either `reset()` was called (no explicit value)
+    // or `reset(value: null)` was called.
+    // In line with "If no value is provided it should assign the initial value",
+    // we use `_initialValue` when `value` is `null`.
+    // If `value` is explicitly provided and not null, we use that.
+    super.reset(
+      value: value ?? _initialValue,
+      updateParent: updateParent,
+      emitEvent: emitEvent,
+      removeFocus: removeFocus,
+      disabled: disabled,
+    );
   }
 
   @override

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -52,10 +52,10 @@ abstract class AbstractControl<T> {
     int asyncValidatorsDebounceTime = 250,
     bool disabled = false,
     bool touched = false,
-  })  : assert(asyncValidatorsDebounceTime >= 0),
-        _asyncValidatorsDebounceTime = asyncValidatorsDebounceTime,
-        _touched = touched,
-        _status = disabled ? ControlStatus.disabled : ControlStatus.valid {
+  }) : assert(asyncValidatorsDebounceTime >= 0),
+       _asyncValidatorsDebounceTime = asyncValidatorsDebounceTime,
+       _touched = touched,
+       _status = disabled ? ControlStatus.disabled : ControlStatus.valid {
     setValidators(validators);
     setAsyncValidators(asyncValidators);
   }
@@ -1166,11 +1166,11 @@ class FormGroup extends FormControlCollection<Map<String, Object?>> {
     super.asyncValidators,
     super.asyncValidatorsDebounceTime,
     bool disabled = false,
-  })  : assert(
-          !controls.keys.any((name) => name.contains(_controlNameDelimiter)),
-          'Control name should not contain dot($_controlNameDelimiter)',
-        ),
-        super(disabled: disabled) {
+  }) : assert(
+         !controls.keys.any((name) => name.contains(_controlNameDelimiter)),
+         'Control name should not contain dot($_controlNameDelimiter)',
+       ),
+       super(disabled: disabled) {
     addAll(controls);
 
     if (disabled) {
@@ -1693,7 +1693,8 @@ class FormArray<T> extends FormControlCollection<List<T?>> {
   ///
   /// Retrieves all values regardless of disabled status.
   @override
-  List<T?> get rawValue => _controls.map<T?>((control) {
+  List<T?> get rawValue =>
+      _controls.map<T?>((control) {
         if (control is FormControlCollection<T?>) {
           return (control as FormControlCollection<T?>).rawValue;
         }
@@ -2094,13 +2095,14 @@ class FormArray<T> extends FormControlCollection<List<T?>> {
     }
 
     if (value != null && value.length > _controls.length) {
-      final newControls = value
-          .toList()
-          .asMap()
-          .entries
-          .where((entry) => entry.key >= _controls.length)
-          .map((entry) => FormControl<T>(value: entry.value))
-          .toList();
+      final newControls =
+          value
+              .toList()
+              .asMap()
+              .entries
+              .where((entry) => entry.key >= _controls.length)
+              .map((entry) => FormControl<T>(value: entry.value))
+              .toList();
 
       addAll(newControls, updateParent: updateParent, emitEvent: emitEvent);
     } else {

--- a/lib/src/validators/delegate_async_validator.dart
+++ b/lib/src/validators/delegate_async_validator.dart
@@ -6,8 +6,8 @@ import 'package:reactive_forms/reactive_forms.dart';
 
 /// Signature of a function that receives a control and returns a Future
 /// that emits validation errors if present, otherwise null.
-typedef AsyncValidatorFunction = Future<Map<String, dynamic>?> Function(
-    AbstractControl<dynamic> control);
+typedef AsyncValidatorFunction =
+    Future<Map<String, dynamic>?> Function(AbstractControl<dynamic> control);
 
 /// Validator that delegates the validation to an external function.
 class DelegateAsyncValidator extends AsyncValidator<dynamic> {
@@ -18,8 +18,8 @@ class DelegateAsyncValidator extends AsyncValidator<dynamic> {
   /// The [DelegateAsyncValidator] validator delegates the validation to the
   /// external asynchronous [validator] function.
   const DelegateAsyncValidator(AsyncValidatorFunction asyncValidator)
-      : _asyncValidator = asyncValidator,
-        super();
+    : _asyncValidator = asyncValidator,
+      super();
 
   @override
   Future<Map<String, dynamic>?> validate(AbstractControl<dynamic> control) {

--- a/lib/src/validators/delegate_validator.dart
+++ b/lib/src/validators/delegate_validator.dart
@@ -6,8 +6,8 @@ import 'package:reactive_forms/reactive_forms.dart';
 
 /// Signature of a function that receives a control and synchronously
 /// returns a map of validation errors if present, otherwise null.
-typedef ValidatorFunction = Map<String, dynamic>? Function(
-    AbstractControl<dynamic> control);
+typedef ValidatorFunction =
+    Map<String, dynamic>? Function(AbstractControl<dynamic> control);
 
 /// Validator that delegates the validation to an external function.
 class DelegateValidator extends Validator<dynamic> {
@@ -18,8 +18,8 @@ class DelegateValidator extends Validator<dynamic> {
   /// The [DelegateValidator] validator delegates the validation to the
   /// external [validator] function.
   const DelegateValidator(ValidatorFunction validator)
-      : _validator = validator,
-        super();
+    : _validator = validator,
+      super();
 
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {

--- a/lib/src/validators/equals_validator.dart
+++ b/lib/src/validators/equals_validator.dart
@@ -26,10 +26,10 @@ class EqualsValidator<T> extends Validator<dynamic> {
     return control.value == value
         ? null
         : <String, dynamic>{
-            validationMessage: <String, dynamic>{
-              'required': value,
-              'actual': control.value,
-            },
-          };
+          validationMessage: <String, dynamic>{
+            'required': value,
+            'actual': control.value,
+          },
+        };
   }
 }

--- a/lib/src/validators/max_length_validator.dart
+++ b/lib/src/validators/max_length_validator.dart
@@ -36,10 +36,10 @@ class MaxLengthValidator extends Validator<dynamic> {
     return (collection == null || collection.length <= maxLength)
         ? null
         : <String, dynamic>{
-            ValidationMessage.maxLength: {
-              'requiredLength': maxLength,
-              'actualLength': collection.length,
-            },
-          };
+          ValidationMessage.maxLength: {
+            'requiredLength': maxLength,
+            'actualLength': collection.length,
+          },
+        };
   }
 }

--- a/lib/src/validators/min_length_validator.dart
+++ b/lib/src/validators/min_length_validator.dart
@@ -36,10 +36,10 @@ class MinLengthValidator extends Validator<dynamic> {
     return (collection != null && collection.length >= minLength)
         ? null
         : <String, dynamic>{
-            ValidationMessage.minLength: {
-              'requiredLength': minLength,
-              'actualLength': collection != null ? collection.length : 0,
-            },
-          };
+          ValidationMessage.minLength: {
+            'requiredLength': minLength,
+            'actualLength': collection != null ? collection.length : 0,
+          },
+        };
   }
 }

--- a/lib/src/validators/pattern_validator.dart
+++ b/lib/src/validators/pattern_validator.dart
@@ -24,10 +24,10 @@ class PatternValidator extends Validator<dynamic> {
             evaluator.hasMatch(control.value.toString()))
         ? null
         : <String, dynamic>{
-            validationMessage: {
-              'requiredPattern': evaluator.pattern,
-              'actualValue': control.value as Object,
-            },
-          };
+          validationMessage: {
+            'requiredPattern': evaluator.pattern,
+            'actualValue': control.value as Object,
+          },
+        };
   }
 }

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -16,8 +16,7 @@ class Validators {
   /// asynchronous [validator] function.
   static AsyncValidator<dynamic> delegateAsync(
     AsyncValidatorFunction validator,
-  ) =>
-      DelegateAsyncValidator(validator);
+  ) => DelegateAsyncValidator(validator);
 
   /// Creates a validator that requires the control have a non-empty value.
   static Validator<dynamic> get required => const RequiredValidator();
@@ -25,9 +24,9 @@ class Validators {
   /// Creates a validator that requires the control's value be true.
   /// This validator is commonly used for required checkboxes.
   static Validator<dynamic> get requiredTrue => const EqualsValidator<bool>(
-        true,
-        validationMessage: ValidationMessage.requiredTrue,
-      );
+    true,
+    validationMessage: ValidationMessage.requiredTrue,
+  );
 
   /// Creates a validator that requires the control's value pass an email
   /// validation test.
@@ -41,12 +40,11 @@ class Validators {
     bool allowNull = false,
     int allowedDecimals = 0,
     bool allowNegatives = true,
-  }) =>
-      NumberValidator(
-        allowNull: allowNull,
-        allowedDecimals: allowedDecimals,
-        allowNegatives: allowNegatives,
-      );
+  }) => NumberValidator(
+    allowNull: allowNull,
+    allowedDecimals: allowedDecimals,
+    allowNegatives: allowNegatives,
+  );
 
   /// Creates a validator that validates if the control's value is a valid
   /// credit card number.

--- a/lib/src/value_accessors/datetime_value_accessor.dart
+++ b/lib/src/value_accessors/datetime_value_accessor.dart
@@ -11,7 +11,7 @@ class DateTimeValueAccessor extends ControlValueAccessor<DateTime, String> {
   final DateFormat dateTimeFormat;
 
   DateTimeValueAccessor({DateFormat? dateTimeFormat})
-      : dateTimeFormat = dateTimeFormat ?? DateFormat('yyyy/MM/dd');
+    : dateTimeFormat = dateTimeFormat ?? DateFormat('yyyy/MM/dd');
 
   @override
   String modelToViewValue(DateTime? modelValue) {

--- a/lib/src/widgets/inherited_streamer.dart
+++ b/lib/src/widgets/inherited_streamer.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 
 abstract class InheritedStreamer<T> extends InheritedWidget {
   const InheritedStreamer(this.stream, Widget child, {super.key})
-      : super(child: child);
+    : super(child: child);
 
   final Stream<T> stream;
 

--- a/lib/src/widgets/reactive_checkbox.dart
+++ b/lib/src/widgets/reactive_checkbox.dart
@@ -43,36 +43,37 @@ class ReactiveCheckbox extends ReactiveFocusableFormField<bool, bool> {
     ReactiveFormFieldCallback<bool>? onChanged,
     ShowErrorsFunction<bool>? showErrors,
   }) : super(
-          showErrors: showErrors ??
-              (control) =>
-                  control.invalid && (control.dirty || control.touched),
-          builder: (field) {
-            return Checkbox(
-              value: tristate ? field.value : field.value ?? false,
-              tristate: tristate,
-              mouseCursor: mouseCursor,
-              activeColor: activeColor,
-              checkColor: checkColor,
-              focusColor: focusColor,
-              hoverColor: hoverColor,
-              materialTapTargetSize: materialTapTargetSize,
-              visualDensity: visualDensity,
-              autofocus: autofocus,
-              fillColor: fillColor,
-              overlayColor: overlayColor,
-              splashRadius: splashRadius,
-              focusNode: field.focusNode,
-              shape: shape,
-              side: side,
-              isError: field.errorText != null,
-              onChanged: field.control.enabled
-                  ? (value) {
-                      field.didChange(value);
-                      onChanged?.call(field.control);
-                    }
-                  : null,
-              semanticLabel: semanticLabel,
-            );
-          },
-        );
+         showErrors:
+             showErrors ??
+             (control) => control.invalid && (control.dirty || control.touched),
+         builder: (field) {
+           return Checkbox(
+             value: tristate ? field.value : field.value ?? false,
+             tristate: tristate,
+             mouseCursor: mouseCursor,
+             activeColor: activeColor,
+             checkColor: checkColor,
+             focusColor: focusColor,
+             hoverColor: hoverColor,
+             materialTapTargetSize: materialTapTargetSize,
+             visualDensity: visualDensity,
+             autofocus: autofocus,
+             fillColor: fillColor,
+             overlayColor: overlayColor,
+             splashRadius: splashRadius,
+             focusNode: field.focusNode,
+             shape: shape,
+             side: side,
+             isError: field.errorText != null,
+             onChanged:
+                 field.control.enabled
+                     ? (value) {
+                       field.didChange(value);
+                       onChanged?.call(field.control);
+                     }
+                     : null,
+             semanticLabel: semanticLabel,
+           );
+         },
+       );
 }

--- a/lib/src/widgets/reactive_checkbox_list_tile.dart
+++ b/lib/src/widgets/reactive_checkbox_list_tile.dart
@@ -56,50 +56,51 @@ class ReactiveCheckboxListTile extends ReactiveFocusableFormField<bool, bool> {
     double checkboxScaleFactor = 1.0,
     ShowErrorsFunction<bool>? showErrors,
   }) : super(
-          showErrors: showErrors ??
-              (control) =>
-                  control.invalid && (control.dirty || control.touched),
-          builder: (field) {
-            return CheckboxListTile(
-              value: tristate ? field.value : field.value ?? false,
-              mouseCursor: mouseCursor,
-              fillColor: fillColor,
-              hoverColor: hoverColor,
-              overlayColor: overlayColor,
-              materialTapTargetSize: materialTapTargetSize,
-              splashRadius: splashRadius,
-              activeColor: activeColor,
-              checkColor: checkColor,
-              onFocusChange: onFocusChange,
-              isError: field.errorText != null,
-              title: title,
-              subtitle: subtitle,
-              isThreeLine: isThreeLine,
-              dense: dense,
-              secondary: secondary,
-              controlAffinity: controlAffinity,
-              autofocus: autofocus,
-              contentPadding: contentPadding,
-              tristate: tristate,
-              selectedTileColor: selectedTileColor,
-              tileColor: tileColor,
-              shape: shape,
-              selected: selected,
-              visualDensity: visualDensity,
-              focusNode: field.focusNode,
-              enableFeedback: enableFeedback,
-              checkboxSemanticLabel: checkboxSemanticLabel,
-              checkboxScaleFactor: checkboxScaleFactor,
-              checkboxShape: checkboxShape,
-              side: side,
-              enabled: field.control.enabled,
-              onChanged: field.control.enabled
-                  ? (value) {
-                      field.didChange(value);
-                      onChanged?.call(field.control);
-                    }
-                  : null,
-            );
-          },
-        );
+         showErrors:
+             showErrors ??
+             (control) => control.invalid && (control.dirty || control.touched),
+         builder: (field) {
+           return CheckboxListTile(
+             value: tristate ? field.value : field.value ?? false,
+             mouseCursor: mouseCursor,
+             fillColor: fillColor,
+             hoverColor: hoverColor,
+             overlayColor: overlayColor,
+             materialTapTargetSize: materialTapTargetSize,
+             splashRadius: splashRadius,
+             activeColor: activeColor,
+             checkColor: checkColor,
+             onFocusChange: onFocusChange,
+             isError: field.errorText != null,
+             title: title,
+             subtitle: subtitle,
+             isThreeLine: isThreeLine,
+             dense: dense,
+             secondary: secondary,
+             controlAffinity: controlAffinity,
+             autofocus: autofocus,
+             contentPadding: contentPadding,
+             tristate: tristate,
+             selectedTileColor: selectedTileColor,
+             tileColor: tileColor,
+             shape: shape,
+             selected: selected,
+             visualDensity: visualDensity,
+             focusNode: field.focusNode,
+             enableFeedback: enableFeedback,
+             checkboxSemanticLabel: checkboxSemanticLabel,
+             checkboxScaleFactor: checkboxScaleFactor,
+             checkboxShape: checkboxShape,
+             side: side,
+             enabled: field.control.enabled,
+             onChanged:
+                 field.control.enabled
+                     ? (value) {
+                       field.didChange(value);
+                       onChanged?.call(field.control);
+                     }
+                     : null,
+           );
+         },
+       );
 }

--- a/lib/src/widgets/reactive_date_picker.dart
+++ b/lib/src/widgets/reactive_date_picker.dart
@@ -13,11 +13,12 @@ import 'package:reactive_forms/reactive_forms.dart';
 /// that is bound to [ReactiveTimePicker].
 ///
 /// See also [ReactiveDatePickerDelegate].
-typedef ReactiveDatePickerBuilder<T> = Widget Function(
-  BuildContext context,
-  ReactiveDatePickerDelegate<T> picker,
-  Widget? child,
-);
+typedef ReactiveDatePickerBuilder<T> =
+    Widget Function(
+      BuildContext context,
+      ReactiveDatePickerDelegate<T> picker,
+      Widget? child,
+    );
 
 /// This is a convenience widget that wraps the function
 /// [showDatePicker] in a [ReactiveDatePicker].
@@ -91,54 +92,54 @@ class ReactiveDatePicker<T> extends ReactiveFormField<T, DateTime> {
     Icon? switchToCalendarEntryModeIcon,
     ValueChanged<DatePickerEntryMode>? onDatePickerModeChange,
   }) : super(
-          builder: (ReactiveFormFieldState<T, DateTime> field) {
-            return builder(
-              field.context,
-              ReactiveDatePickerDelegate<T>._(
-                field,
-                (field) => showDatePicker(
-                  context: field.context,
-                  initialDate: _getInitialDate(
-                    firstDate,
-                    lastDate,
-                    initialDate ?? field.value ?? DateTime.now(),
-                  ),
-                  firstDate: firstDate,
-                  lastDate: lastDate,
-                  initialEntryMode: initialEntryMode,
-                  selectableDayPredicate: selectableDayPredicate,
-                  helpText: helpText,
-                  cancelText: cancelText,
-                  confirmText: confirmText,
-                  locale: locale,
-                  useRootNavigator: useRootNavigator,
-                  routeSettings: routeSettings,
-                  textDirection: textDirection,
-                  builder: transitionBuilder,
-                  initialDatePickerMode: initialDatePickerMode,
-                  errorFormatText: errorFormatText,
-                  errorInvalidText: errorInvalidText,
-                  fieldHintText: fieldHintText,
-                  fieldLabelText: fieldLabelText,
-                  currentDate: currentDate,
-                  keyboardType: keyboardType,
-                  anchorPoint: anchorPoint,
-                  barrierColor: barrierColor,
-                  barrierDismissible: barrierDismissible,
-                  barrierLabel: barrierLabel,
-                  switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
-                  switchToInputEntryModeIcon: switchToInputEntryModeIcon,
-                  onDatePickerModeChange: onDatePickerModeChange,
-                ).then((value) {
-                  if (value != null) {
-                    field.didChange(value);
-                  }
-                }),
-              ),
-              child,
-            );
-          },
-        );
+         builder: (ReactiveFormFieldState<T, DateTime> field) {
+           return builder(
+             field.context,
+             ReactiveDatePickerDelegate<T>._(
+               field,
+               (field) => showDatePicker(
+                 context: field.context,
+                 initialDate: _getInitialDate(
+                   firstDate,
+                   lastDate,
+                   initialDate ?? field.value ?? DateTime.now(),
+                 ),
+                 firstDate: firstDate,
+                 lastDate: lastDate,
+                 initialEntryMode: initialEntryMode,
+                 selectableDayPredicate: selectableDayPredicate,
+                 helpText: helpText,
+                 cancelText: cancelText,
+                 confirmText: confirmText,
+                 locale: locale,
+                 useRootNavigator: useRootNavigator,
+                 routeSettings: routeSettings,
+                 textDirection: textDirection,
+                 builder: transitionBuilder,
+                 initialDatePickerMode: initialDatePickerMode,
+                 errorFormatText: errorFormatText,
+                 errorInvalidText: errorInvalidText,
+                 fieldHintText: fieldHintText,
+                 fieldLabelText: fieldLabelText,
+                 currentDate: currentDate,
+                 keyboardType: keyboardType,
+                 anchorPoint: anchorPoint,
+                 barrierColor: barrierColor,
+                 barrierDismissible: barrierDismissible,
+                 barrierLabel: barrierLabel,
+                 switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
+                 switchToInputEntryModeIcon: switchToInputEntryModeIcon,
+                 onDatePickerModeChange: onDatePickerModeChange,
+               ).then((value) {
+                 if (value != null) {
+                   field.didChange(value);
+                 }
+               }),
+             ),
+             child,
+           );
+         },
+       );
 
   static DateTime _getInitialDate(
     DateTime firstDate,
@@ -162,8 +163,8 @@ class ReactiveDatePicker<T> extends ReactiveFormField<T, DateTime> {
 }
 
 /// Definition of the function responsible for show the date picker.
-typedef _ShowDatePickerCallback<T> = void Function(
-    ReactiveFormFieldState<T?, DateTime> field);
+typedef _ShowDatePickerCallback<T> =
+    void Function(ReactiveFormFieldState<T?, DateTime> field);
 
 /// This class is responsible of showing the picker dialog.
 ///

--- a/lib/src/widgets/reactive_dropdown_field.dart
+++ b/lib/src/widgets/reactive_dropdown_field.dart
@@ -56,70 +56,72 @@ class ReactiveDropdownField<T> extends ReactiveFocusableFormField<T, T> {
     EdgeInsetsGeometry? padding,
     ReactiveFormFieldCallback<T>? onTap,
     ReactiveFormFieldCallback<T>? onChanged,
-  })  : assert(itemHeight == null || itemHeight > 0),
-        super(
-          builder: (ReactiveFormFieldState<T, T> field) {
-            final effectiveDecoration = decoration.applyDefaults(
-              Theme.of(field.context).inputDecorationTheme,
-            );
+  }) : assert(itemHeight == null || itemHeight > 0),
+       super(
+         builder: (ReactiveFormFieldState<T, T> field) {
+           final effectiveDecoration = decoration.applyDefaults(
+             Theme.of(field.context).inputDecorationTheme,
+           );
 
-            var effectiveValue = field.value;
-            if (effectiveValue != null &&
-                !items.any((item) => item.value == effectiveValue)) {
-              effectiveValue = null;
-            }
+           var effectiveValue = field.value;
+           if (effectiveValue != null &&
+               !items.any((item) => item.value == effectiveValue)) {
+             effectiveValue = null;
+           }
 
-            final isDisabled = readOnly || field.control.disabled;
-            var effectiveDisabledHint = disabledHint;
-            if (isDisabled && disabledHint == null) {
-              final selectedItemIndex = items.indexWhere(
-                (item) => item.value == effectiveValue,
-              );
-              if (selectedItemIndex > -1) {
-                effectiveDisabledHint = selectedItemBuilder != null
-                    ? selectedItemBuilder(
-                        field.context,
-                      ).elementAt(selectedItemIndex)
-                    : items.elementAt(selectedItemIndex).child;
-              }
-            }
+           final isDisabled = readOnly || field.control.disabled;
+           var effectiveDisabledHint = disabledHint;
+           if (isDisabled && disabledHint == null) {
+             final selectedItemIndex = items.indexWhere(
+               (item) => item.value == effectiveValue,
+             );
+             if (selectedItemIndex > -1) {
+               effectiveDisabledHint =
+                   selectedItemBuilder != null
+                       ? selectedItemBuilder(
+                         field.context,
+                       ).elementAt(selectedItemIndex)
+                       : items.elementAt(selectedItemIndex).child;
+             }
+           }
 
-            return DropdownButtonFormField<T>(
-              value: effectiveValue,
-              decoration: effectiveDecoration.copyWith(
-                errorText: field.errorText,
-                enabled: !isDisabled,
-              ),
-              items: items,
-              selectedItemBuilder: selectedItemBuilder,
-              hint: hint,
-              disabledHint: effectiveDisabledHint,
-              elevation: elevation,
-              style: style,
-              icon: icon,
-              iconDisabledColor: iconDisabledColor,
-              iconEnabledColor: iconEnabledColor,
-              iconSize: iconSize,
-              isDense: isDense,
-              isExpanded: isExpanded,
-              itemHeight: itemHeight,
-              focusNode: field.focusNode,
-              dropdownColor: dropdownColor,
-              focusColor: focusColor,
-              autofocus: autofocus,
-              menuMaxHeight: menuMaxHeight,
-              enableFeedback: enableFeedback,
-              alignment: alignment,
-              borderRadius: borderRadius,
-              padding: padding,
-              onTap: onTap != null ? () => onTap(field.control) : null,
-              onChanged: isDisabled
-                  ? null
-                  : (value) {
-                      field.didChange(value);
-                      onChanged?.call(field.control);
-                    },
-            );
-          },
-        );
+           return DropdownButtonFormField<T>(
+             value: effectiveValue,
+             decoration: effectiveDecoration.copyWith(
+               errorText: field.errorText,
+               enabled: !isDisabled,
+             ),
+             items: items,
+             selectedItemBuilder: selectedItemBuilder,
+             hint: hint,
+             disabledHint: effectiveDisabledHint,
+             elevation: elevation,
+             style: style,
+             icon: icon,
+             iconDisabledColor: iconDisabledColor,
+             iconEnabledColor: iconEnabledColor,
+             iconSize: iconSize,
+             isDense: isDense,
+             isExpanded: isExpanded,
+             itemHeight: itemHeight,
+             focusNode: field.focusNode,
+             dropdownColor: dropdownColor,
+             focusColor: focusColor,
+             autofocus: autofocus,
+             menuMaxHeight: menuMaxHeight,
+             enableFeedback: enableFeedback,
+             alignment: alignment,
+             borderRadius: borderRadius,
+             padding: padding,
+             onTap: onTap != null ? () => onTap(field.control) : null,
+             onChanged:
+                 isDisabled
+                     ? null
+                     : (value) {
+                       field.didChange(value);
+                       onChanged?.call(field.control);
+                     },
+           );
+         },
+       );
 }

--- a/lib/src/widgets/reactive_form.dart
+++ b/lib/src/widgets/reactive_form.dart
@@ -61,8 +61,11 @@ class ReactiveForm<T> extends StatelessWidget {
           ?.control;
     }
 
-    final element = context.getElementForInheritedWidgetOfExactType<
-        FormControlInheritedStreamer>();
+    final element =
+        context
+            .getElementForInheritedWidgetOfExactType<
+              FormControlInheritedStreamer
+            >();
     return element == null
         ? null
         : (element.widget as FormControlInheritedStreamer).control;
@@ -79,10 +82,11 @@ class ReactiveForm<T> extends StatelessWidget {
         builder: (context, snapshot) {
           return PopScope<T>(
             canPop: canPop?.call(formGroup) ?? true,
-            onPopInvokedWithResult: onPopInvokedWithResult != null
-                ? (didPop, result) =>
-                    onPopInvokedWithResult!(formGroup, didPop, result)
-                : null,
+            onPopInvokedWithResult:
+                onPopInvokedWithResult != null
+                    ? (didPop, result) =>
+                        onPopInvokedWithResult!(formGroup, didPop, result)
+                    : null,
             child: child,
           );
         },

--- a/lib/src/widgets/reactive_form_array.dart
+++ b/lib/src/widgets/reactive_form_array.dart
@@ -11,11 +11,12 @@ import '../widgets/form_control_inherited_notifier.dart';
 /// This is the signature of a function that receives the [context],
 /// the [formArray] and an optional [child] and returns a [Widget].
 ///
-typedef ReactiveFormArrayBuilder<T> = Widget Function(
-  BuildContext context,
-  FormArray<T> formArray,
-  Widget? child,
-);
+typedef ReactiveFormArrayBuilder<T> =
+    Widget Function(
+      BuildContext context,
+      FormArray<T> formArray,
+      Widget? child,
+    );
 
 /// This class is responsible for create a [FormControlInheritedStreamer] for
 /// exposing a [FormArray] to all descendants widgets.
@@ -42,10 +43,10 @@ class ReactiveFormArray<T> extends StatefulWidget {
     this.formArray,
     this.child,
   }) : assert(
-          (formArrayName != null && formArray == null) ||
-              (formArrayName == null && formArray != null),
-          'Must provide a formArrayName or a formArray, but not both at the same time.',
-        );
+         (formArrayName != null && formArray == null) ||
+             (formArrayName == null && formArray != null),
+         'Must provide a formArrayName or a formArray, but not both at the same time.',
+       );
 
   @override
   ReactiveFormArrayState<T> createState() => ReactiveFormArrayState<T>();

--- a/lib/src/widgets/reactive_form_consumer.dart
+++ b/lib/src/widgets/reactive_form_consumer.dart
@@ -8,8 +8,8 @@ import 'package:reactive_forms/reactive_forms.dart';
 /// Builder function definition of the [ReactiveFormConsumer] builder.
 ///
 /// See also [ReactiveFormConsumer].
-typedef ReactiveFormConsumerBuilder = Widget Function(
-    BuildContext context, FormGroup formGroup, Widget? child);
+typedef ReactiveFormConsumerBuilder =
+    Widget Function(BuildContext context, FormGroup formGroup, Widget? child);
 
 /// Obtains [FormGroup] from its ancestors and passes its value to [builder].
 ///

--- a/lib/src/widgets/reactive_form_field.dart
+++ b/lib/src/widgets/reactive_form_field.dart
@@ -10,8 +10,8 @@ import 'package:reactive_forms/reactive_forms.dart';
 /// Signature for building the widget representing the form field.
 ///
 /// Used by [FormField.builder].
-typedef ReactiveFormFieldBuilder<T, K> = Widget Function(
-    ReactiveFormFieldState<T, K> field);
+typedef ReactiveFormFieldBuilder<T, K> =
+    Widget Function(ReactiveFormFieldState<T, K> field);
 
 /// Signature for customize when to show errors in a widget.
 typedef ShowErrorsFunction<T> = bool Function(FormControl<T> control);
@@ -70,12 +70,12 @@ class ReactiveFormField<ModelDataType, ViewDataType> extends StatefulWidget {
     this.validationMessages,
     this.focusNode,
     required ReactiveFormFieldBuilder<ModelDataType, ViewDataType> builder,
-  })  : assert(
-          (formControlName != null && formControl == null) ||
-              (formControlName == null && formControl != null),
-          'Must provide a formControlName or a formControl, but not both at the same time.',
-        ),
-        _builder = builder;
+  }) : assert(
+         (formControlName != null && formControl == null) ||
+             (formControlName == null && formControl != null),
+         'Must provide a formControlName or a formControl, but not both at the same time.',
+       ),
+       _builder = builder;
 
   @override
   ReactiveFormFieldState<ModelDataType, ViewDataType> createState() =>

--- a/lib/src/widgets/reactive_form_pop_scope.dart
+++ b/lib/src/widgets/reactive_form_pop_scope.dart
@@ -33,10 +33,11 @@ class ReactiveFormPopScope<T> extends StatelessWidget {
       builder: (context, formGroup, _) {
         return PopScope<T>(
           canPop: canPop?.call(formGroup) ?? true,
-          onPopInvokedWithResult: onPopInvokedWithResult != null
-              ? (didPop, result) =>
-                  onPopInvokedWithResult!(formGroup, didPop, result)
-              : null,
+          onPopInvokedWithResult:
+              onPopInvokedWithResult != null
+                  ? (didPop, result) =>
+                      onPopInvokedWithResult!(formGroup, didPop, result)
+                  : null,
           child: child,
         );
       },

--- a/lib/src/widgets/reactive_radio.dart
+++ b/lib/src/widgets/reactive_radio.dart
@@ -47,29 +47,30 @@ class ReactiveRadio<T> extends ReactiveFocusableFormField<T, T> {
     super.focusNode,
     ReactiveFormFieldCallback<T>? onChanged,
   }) : super(
-          builder: (field) {
-            return Radio<T>(
-              value: value,
-              groupValue: field.value,
-              activeColor: activeColor,
-              focusColor: focusColor,
-              hoverColor: hoverColor,
-              fillColor: fillColor,
-              overlayColor: overlayColor,
-              mouseCursor: mouseCursor,
-              splashRadius: splashRadius,
-              materialTapTargetSize: materialTapTargetSize,
-              visualDensity: visualDensity,
-              autofocus: autofocus,
-              toggleable: toggleable,
-              focusNode: field.focusNode,
-              onChanged: field.control.enabled
-                  ? (value) {
-                      field.didChange(value);
-                      onChanged?.call(field.control);
-                    }
-                  : null,
-            );
-          },
-        );
+         builder: (field) {
+           return Radio<T>(
+             value: value,
+             groupValue: field.value,
+             activeColor: activeColor,
+             focusColor: focusColor,
+             hoverColor: hoverColor,
+             fillColor: fillColor,
+             overlayColor: overlayColor,
+             mouseCursor: mouseCursor,
+             splashRadius: splashRadius,
+             materialTapTargetSize: materialTapTargetSize,
+             visualDensity: visualDensity,
+             autofocus: autofocus,
+             toggleable: toggleable,
+             focusNode: field.focusNode,
+             onChanged:
+                 field.control.enabled
+                     ? (value) {
+                       field.didChange(value);
+                       onChanged?.call(field.control);
+                     }
+                     : null,
+           );
+         },
+       );
 }

--- a/lib/src/widgets/reactive_radio_list_tile.dart
+++ b/lib/src/widgets/reactive_radio_list_tile.dart
@@ -57,42 +57,43 @@ class ReactiveRadioListTile<T> extends ReactiveFocusableFormField<T, T> {
     double radioScaleFactor = 1.0,
     ValueChanged<bool>? onFocusChange,
   }) : super(
-          builder: (field) {
-            return RadioListTile<T>(
-              value: value,
-              groupValue: field.value,
-              mouseCursor: mouseCursor,
-              activeColor: activeColor,
-              hoverColor: hoverColor,
-              overlayColor: overlayColor,
-              materialTapTargetSize: materialTapTargetSize,
-              fillColor: fillColor,
-              splashRadius: splashRadius,
-              onFocusChange: onFocusChange,
-              selectedTileColor: selectedTileColor,
-              tileColor: tileColor,
-              title: title,
-              subtitle: subtitle,
-              isThreeLine: isThreeLine,
-              dense: dense,
-              secondary: secondary,
-              controlAffinity: controlAffinity,
-              contentPadding: contentPadding,
-              toggleable: toggleable,
-              shape: shape,
-              selected: selected,
-              autofocus: autofocus,
-              visualDensity: visualDensity,
-              focusNode: field.focusNode,
-              enableFeedback: enableFeedback,
-              radioScaleFactor: radioScaleFactor,
-              onChanged: field.control.enabled
-                  ? (value) {
-                      field.didChange(value);
-                      onChanged?.call(field.control);
-                    }
-                  : null,
-            );
-          },
-        );
+         builder: (field) {
+           return RadioListTile<T>(
+             value: value,
+             groupValue: field.value,
+             mouseCursor: mouseCursor,
+             activeColor: activeColor,
+             hoverColor: hoverColor,
+             overlayColor: overlayColor,
+             materialTapTargetSize: materialTapTargetSize,
+             fillColor: fillColor,
+             splashRadius: splashRadius,
+             onFocusChange: onFocusChange,
+             selectedTileColor: selectedTileColor,
+             tileColor: tileColor,
+             title: title,
+             subtitle: subtitle,
+             isThreeLine: isThreeLine,
+             dense: dense,
+             secondary: secondary,
+             controlAffinity: controlAffinity,
+             contentPadding: contentPadding,
+             toggleable: toggleable,
+             shape: shape,
+             selected: selected,
+             autofocus: autofocus,
+             visualDensity: visualDensity,
+             focusNode: field.focusNode,
+             enableFeedback: enableFeedback,
+             radioScaleFactor: radioScaleFactor,
+             onChanged:
+                 field.control.enabled
+                     ? (value) {
+                       field.didChange(value);
+                       onChanged?.call(field.control);
+                     }
+                     : null,
+           );
+         },
+       );
 }

--- a/lib/src/widgets/reactive_slider.dart
+++ b/lib/src/widgets/reactive_slider.dart
@@ -54,51 +54,51 @@ class ReactiveSlider extends ReactiveFocusableFormField<num, double> {
     Color? secondaryActiveColor,
     WidgetStateProperty<Color?>? overlayColor,
   }) : super(
-          builder: (field) {
-            var value = field.value;
-            if (value == null) {
-              value = min;
-            } else if (value < min) {
-              value = min;
-            } else if (value > max) {
-              value = max;
-            }
+         builder: (field) {
+           var value = field.value;
+           if (value == null) {
+             value = min;
+           } else if (value < min) {
+             value = min;
+           } else if (value > max) {
+             value = max;
+           }
 
-            return Slider(
-              value: value,
-              min: min,
-              max: max,
-              divisions: divisions,
-              secondaryTrackValue: secondaryTrackValue,
-              secondaryActiveColor: secondaryActiveColor,
-              overlayColor: overlayColor,
-              label: labelBuilder != null
-                  ? labelBuilder(field.value ?? min)
-                  : null,
-              activeColor: activeColor,
-              inactiveColor: inactiveColor,
-              thumbColor: thumbColor,
-              semanticFormatterCallback: semanticFormatterCallback,
-              mouseCursor: mouseCursor,
-              autofocus: autofocus,
-              focusNode: field.focusNode,
-              padding: padding,
-              allowedInteraction: allowedInteraction,
-              onChangeEnd: onChangeEnd != null
-                  ? (_) => onChangeEnd(field.control)
-                  : null,
-              onChangeStart: onChangeStart != null
-                  ? (_) => onChangeStart(field.control)
-                  : null,
-              onChanged: field.control.enabled
-                  ? (value) {
-                      field.didChange(value);
-                      onChanged?.call(field.control);
-                    }
-                  : null,
-            );
-          },
-        );
+           return Slider(
+             value: value,
+             min: min,
+             max: max,
+             divisions: divisions,
+             secondaryTrackValue: secondaryTrackValue,
+             secondaryActiveColor: secondaryActiveColor,
+             overlayColor: overlayColor,
+             label:
+                 labelBuilder != null ? labelBuilder(field.value ?? min) : null,
+             activeColor: activeColor,
+             inactiveColor: inactiveColor,
+             thumbColor: thumbColor,
+             semanticFormatterCallback: semanticFormatterCallback,
+             mouseCursor: mouseCursor,
+             autofocus: autofocus,
+             focusNode: field.focusNode,
+             padding: padding,
+             allowedInteraction: allowedInteraction,
+             onChangeEnd:
+                 onChangeEnd != null ? (_) => onChangeEnd(field.control) : null,
+             onChangeStart:
+                 onChangeStart != null
+                     ? (_) => onChangeStart(field.control)
+                     : null,
+             onChanged:
+                 field.control.enabled
+                     ? (value) {
+                       field.didChange(value);
+                       onChanged?.call(field.control);
+                     }
+                     : null,
+           );
+         },
+       );
 
   @override
   ReactiveFormFieldState<num, double> createState() => _ReactiveSliderState();

--- a/lib/src/widgets/reactive_status_listenable_builder.dart
+++ b/lib/src/widgets/reactive_status_listenable_builder.dart
@@ -38,10 +38,10 @@ class ReactiveStatusListenableBuilder extends StatelessWidget {
     required this.builder,
     this.child,
   }) : assert(
-          (formControlName != null && formControl == null) ||
-              (formControlName == null && formControl != null),
-          'Must provide a formControlName or a formControl, but not both at the same time.',
-        );
+         (formControlName != null && formControl == null) ||
+             (formControlName == null && formControl != null),
+         'Must provide a formControlName or a formControl, but not both at the same time.',
+       );
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/widgets/reactive_switch.dart
+++ b/lib/src/widgets/reactive_switch.dart
@@ -62,42 +62,43 @@ class ReactiveSwitch extends ReactiveFocusableFormField<bool, bool> {
     WidgetStateProperty<Icon?>? thumbIcon,
     ValueChanged<bool>? onFocusChange,
   }) : super(
-          builder: (field) {
-            return Switch(
-              value: field.value ?? false,
-              activeColor: activeColor,
-              trackOutlineColor: trackOutlineColor,
-              thumbIcon: thumbIcon,
-              onFocusChange: onFocusChange,
-              activeTrackColor: activeTrackColor,
-              inactiveThumbColor: inactiveThumbColor,
-              inactiveTrackColor: inactiveTrackColor,
-              activeThumbImage: activeThumbImage,
-              onActiveThumbImageError: onActiveThumbImageError,
-              inactiveThumbImage: inactiveThumbImage,
-              onInactiveThumbImageError: onInactiveThumbImageError,
-              materialTapTargetSize: materialTapTargetSize,
-              dragStartBehavior: dragStartBehavior,
-              focusColor: focusColor,
-              hoverColor: hoverColor,
-              autofocus: autofocus,
-              thumbColor: thumbColor,
-              trackColor: trackColor,
-              mouseCursor: mouseCursor,
-              overlayColor: overlayColor,
-              splashRadius: splashRadius,
-              focusNode: field.focusNode,
-              padding: padding,
-              trackOutlineWidth: trackOutlineWidth,
-              onChanged: field.control.enabled
-                  ? (value) {
-                      field.didChange(value);
-                      onChanged?.call(field.control);
-                    }
-                  : null,
-            );
-          },
-        );
+         builder: (field) {
+           return Switch(
+             value: field.value ?? false,
+             activeColor: activeColor,
+             trackOutlineColor: trackOutlineColor,
+             thumbIcon: thumbIcon,
+             onFocusChange: onFocusChange,
+             activeTrackColor: activeTrackColor,
+             inactiveThumbColor: inactiveThumbColor,
+             inactiveTrackColor: inactiveTrackColor,
+             activeThumbImage: activeThumbImage,
+             onActiveThumbImageError: onActiveThumbImageError,
+             inactiveThumbImage: inactiveThumbImage,
+             onInactiveThumbImageError: onInactiveThumbImageError,
+             materialTapTargetSize: materialTapTargetSize,
+             dragStartBehavior: dragStartBehavior,
+             focusColor: focusColor,
+             hoverColor: hoverColor,
+             autofocus: autofocus,
+             thumbColor: thumbColor,
+             trackColor: trackColor,
+             mouseCursor: mouseCursor,
+             overlayColor: overlayColor,
+             splashRadius: splashRadius,
+             focusNode: field.focusNode,
+             padding: padding,
+             trackOutlineWidth: trackOutlineWidth,
+             onChanged:
+                 field.control.enabled
+                     ? (value) {
+                       field.didChange(value);
+                       onChanged?.call(field.control);
+                     }
+                     : null,
+           );
+         },
+       );
 
   /// Creates a [ReactiveSwitch] that wraps a [CupertinoSwitch] if the
   /// target platform is iOS, creates a material design switch otherwise.
@@ -150,41 +151,42 @@ class ReactiveSwitch extends ReactiveFocusableFormField<bool, bool> {
     double? splashRadius,
     ReactiveFormFieldCallback<bool>? onChanged,
   }) : super(
-          builder: (field) {
-            return Switch.adaptive(
-              value: field.value ?? false,
-              activeColor: activeColor,
-              activeTrackColor: activeTrackColor,
-              inactiveThumbColor: inactiveThumbColor,
-              inactiveTrackColor: inactiveTrackColor,
-              activeThumbImage: activeThumbImage,
-              onActiveThumbImageError: onActiveThumbImageError,
-              inactiveThumbImage: inactiveThumbImage,
-              onInactiveThumbImageError: onInactiveThumbImageError,
-              materialTapTargetSize: materialTapTargetSize,
-              dragStartBehavior: dragStartBehavior,
-              focusColor: focusColor,
-              hoverColor: hoverColor,
-              thumbColor: thumbColor,
-              thumbIcon: thumbIcon,
-              trackColor: trackColor,
-              trackOutlineWidth: trackOutlineWidth,
-              trackOutlineColor: trackOutlineColor,
-              mouseCursor: mouseCursor,
-              overlayColor: overlayColor,
-              splashRadius: splashRadius,
-              autofocus: autofocus,
-              padding: padding,
-              applyCupertinoTheme: applyCupertinoTheme,
-              onFocusChange: onFocusChange,
-              focusNode: field.focusNode,
-              onChanged: field.control.enabled
-                  ? (value) {
-                      field.didChange(value);
-                      onChanged?.call(field.control);
-                    }
-                  : null,
-            );
-          },
-        );
+         builder: (field) {
+           return Switch.adaptive(
+             value: field.value ?? false,
+             activeColor: activeColor,
+             activeTrackColor: activeTrackColor,
+             inactiveThumbColor: inactiveThumbColor,
+             inactiveTrackColor: inactiveTrackColor,
+             activeThumbImage: activeThumbImage,
+             onActiveThumbImageError: onActiveThumbImageError,
+             inactiveThumbImage: inactiveThumbImage,
+             onInactiveThumbImageError: onInactiveThumbImageError,
+             materialTapTargetSize: materialTapTargetSize,
+             dragStartBehavior: dragStartBehavior,
+             focusColor: focusColor,
+             hoverColor: hoverColor,
+             thumbColor: thumbColor,
+             thumbIcon: thumbIcon,
+             trackColor: trackColor,
+             trackOutlineWidth: trackOutlineWidth,
+             trackOutlineColor: trackOutlineColor,
+             mouseCursor: mouseCursor,
+             overlayColor: overlayColor,
+             splashRadius: splashRadius,
+             autofocus: autofocus,
+             padding: padding,
+             applyCupertinoTheme: applyCupertinoTheme,
+             onFocusChange: onFocusChange,
+             focusNode: field.focusNode,
+             onChanged:
+                 field.control.enabled
+                     ? (value) {
+                       field.didChange(value);
+                       onChanged?.call(field.control);
+                     }
+                     : null,
+           );
+         },
+       );
 }

--- a/lib/src/widgets/reactive_switch_list_tile.dart
+++ b/lib/src/widgets/reactive_switch_list_tile.dart
@@ -65,52 +65,53 @@ class ReactiveSwitchListTile extends ReactiveFocusableFormField<bool, bool> {
     double? splashRadius,
     ValueChanged<bool>? onFocusChange,
   }) : super(
-          builder: (field) {
-            return SwitchListTile(
-              value: field.value ?? false,
-              activeColor: activeColor,
-              activeTrackColor: activeTrackColor,
-              inactiveThumbColor: inactiveThumbColor,
-              inactiveTrackColor: inactiveTrackColor,
-              mouseCursor: mouseCursor,
-              overlayColor: overlayColor,
-              splashRadius: splashRadius,
-              onFocusChange: onFocusChange,
-              thumbColor: thumbColor,
-              trackColor: trackColor,
-              dragStartBehavior: dragStartBehavior,
-              materialTapTargetSize: materialTapTargetSize,
-              thumbIcon: thumbIcon,
-              trackOutlineColor: trackOutlineColor,
-              onActiveThumbImageError: onActiveThumbImageError,
-              onInactiveThumbImageError: onInactiveThumbImageError,
-              hoverColor: hoverColor,
-              activeThumbImage: activeThumbImage,
-              title: title,
-              subtitle: subtitle,
-              isThreeLine: isThreeLine,
-              dense: dense,
-              contentPadding: contentPadding,
-              secondary: secondary,
-              inactiveThumbImage: inactiveThumbImage,
-              tileColor: tileColor,
-              selected: selected,
-              autofocus: autofocus,
-              controlAffinity: controlAffinity,
-              shape: shape,
-              selectedTileColor: selectedTileColor,
-              visualDensity: visualDensity,
-              enableFeedback: enableFeedback,
-              focusNode: field.focusNode,
-              onChanged: field.control.enabled
-                  ? (value) {
-                      field.didChange(value);
-                      onChanged?.call(field.control);
-                    }
-                  : null,
-            );
-          },
-        );
+         builder: (field) {
+           return SwitchListTile(
+             value: field.value ?? false,
+             activeColor: activeColor,
+             activeTrackColor: activeTrackColor,
+             inactiveThumbColor: inactiveThumbColor,
+             inactiveTrackColor: inactiveTrackColor,
+             mouseCursor: mouseCursor,
+             overlayColor: overlayColor,
+             splashRadius: splashRadius,
+             onFocusChange: onFocusChange,
+             thumbColor: thumbColor,
+             trackColor: trackColor,
+             dragStartBehavior: dragStartBehavior,
+             materialTapTargetSize: materialTapTargetSize,
+             thumbIcon: thumbIcon,
+             trackOutlineColor: trackOutlineColor,
+             onActiveThumbImageError: onActiveThumbImageError,
+             onInactiveThumbImageError: onInactiveThumbImageError,
+             hoverColor: hoverColor,
+             activeThumbImage: activeThumbImage,
+             title: title,
+             subtitle: subtitle,
+             isThreeLine: isThreeLine,
+             dense: dense,
+             contentPadding: contentPadding,
+             secondary: secondary,
+             inactiveThumbImage: inactiveThumbImage,
+             tileColor: tileColor,
+             selected: selected,
+             autofocus: autofocus,
+             controlAffinity: controlAffinity,
+             shape: shape,
+             selectedTileColor: selectedTileColor,
+             visualDensity: visualDensity,
+             enableFeedback: enableFeedback,
+             focusNode: field.focusNode,
+             onChanged:
+                 field.control.enabled
+                     ? (value) {
+                       field.didChange(value);
+                       onChanged?.call(field.control);
+                     }
+                     : null,
+           );
+         },
+       );
 
   /// Creates a [ReactiveSwitchListTile] that wraps a Material [ListTile] with
   /// an adaptive [Switch], following Material design's
@@ -168,51 +169,52 @@ class ReactiveSwitchListTile extends ReactiveFocusableFormField<bool, bool> {
     VisualDensity? visualDensity,
     ReactiveFormFieldCallback<bool>? onChanged,
   }) : super(
-          builder: (field) {
-            return SwitchListTile.adaptive(
-              value: field.value ?? false,
-              activeColor: activeColor,
-              activeTrackColor: activeTrackColor,
-              inactiveThumbColor: inactiveThumbColor,
-              inactiveTrackColor: inactiveTrackColor,
-              activeThumbImage: activeThumbImage,
-              onActiveThumbImageError: onActiveThumbImageError,
-              inactiveThumbImage: inactiveThumbImage,
-              onInactiveThumbImageError: onInactiveThumbImageError,
-              thumbColor: thumbColor,
-              trackColor: trackColor,
-              trackOutlineColor: trackOutlineColor,
-              thumbIcon: thumbIcon,
-              materialTapTargetSize: materialTapTargetSize,
-              dragStartBehavior: dragStartBehavior,
-              mouseCursor: mouseCursor,
-              overlayColor: overlayColor,
-              splashRadius: splashRadius,
-              autofocus: autofocus,
-              applyCupertinoTheme: applyCupertinoTheme,
-              contentPadding: contentPadding,
-              controlAffinity: controlAffinity,
-              dense: dense,
-              enableFeedback: enableFeedback,
-              focusNode: field.focusNode,
-              onFocusChange: onFocusChange,
-              hoverColor: hoverColor,
-              isThreeLine: isThreeLine,
-              secondary: secondary,
-              selected: selected,
-              selectedTileColor: selectedTileColor,
-              shape: shape,
-              subtitle: subtitle,
-              tileColor: tileColor,
-              title: title,
-              visualDensity: visualDensity,
-              onChanged: field.control.enabled
-                  ? (value) {
-                      field.didChange(value);
-                      onChanged?.call(field.control);
-                    }
-                  : null,
-            );
-          },
-        );
+         builder: (field) {
+           return SwitchListTile.adaptive(
+             value: field.value ?? false,
+             activeColor: activeColor,
+             activeTrackColor: activeTrackColor,
+             inactiveThumbColor: inactiveThumbColor,
+             inactiveTrackColor: inactiveTrackColor,
+             activeThumbImage: activeThumbImage,
+             onActiveThumbImageError: onActiveThumbImageError,
+             inactiveThumbImage: inactiveThumbImage,
+             onInactiveThumbImageError: onInactiveThumbImageError,
+             thumbColor: thumbColor,
+             trackColor: trackColor,
+             trackOutlineColor: trackOutlineColor,
+             thumbIcon: thumbIcon,
+             materialTapTargetSize: materialTapTargetSize,
+             dragStartBehavior: dragStartBehavior,
+             mouseCursor: mouseCursor,
+             overlayColor: overlayColor,
+             splashRadius: splashRadius,
+             autofocus: autofocus,
+             applyCupertinoTheme: applyCupertinoTheme,
+             contentPadding: contentPadding,
+             controlAffinity: controlAffinity,
+             dense: dense,
+             enableFeedback: enableFeedback,
+             focusNode: field.focusNode,
+             onFocusChange: onFocusChange,
+             hoverColor: hoverColor,
+             isThreeLine: isThreeLine,
+             secondary: secondary,
+             selected: selected,
+             selectedTileColor: selectedTileColor,
+             shape: shape,
+             subtitle: subtitle,
+             tileColor: tileColor,
+             title: title,
+             visualDensity: visualDensity,
+             onChanged:
+                 field.control.enabled
+                     ? (value) {
+                       field.didChange(value);
+                       onChanged?.call(field.control);
+                     }
+                     : null,
+           );
+         },
+       );
 }

--- a/lib/src/widgets/reactive_text_field.dart
+++ b/lib/src/widgets/reactive_text_field.dart
@@ -165,99 +165,101 @@ class ReactiveTextField<T> extends ReactiveFormField<T, String> {
     SpellCheckConfiguration? spellCheckConfiguration,
     TextMagnifierConfiguration? magnifierConfiguration,
     WidgetStatesController? statesController,
-  })  : _textController = controller,
-        super(
-          builder: (ReactiveFormFieldState<T, String> field) {
-            final state = field as _ReactiveTextFieldState<T>;
-            final effectiveDecoration = decoration.applyDefaults(
-              Theme.of(state.context).inputDecorationTheme,
-            );
+  }) : _textController = controller,
+       super(
+         builder: (ReactiveFormFieldState<T, String> field) {
+           final state = field as _ReactiveTextFieldState<T>;
+           final effectiveDecoration = decoration.applyDefaults(
+             Theme.of(state.context).inputDecorationTheme,
+           );
 
-            return TextField(
-              groupId: groupId,
-              controller: state._textController,
-              focusNode: state.focusNode,
-              decoration: effectiveDecoration.copyWith(
-                errorText: state.errorText,
-              ),
-              keyboardType: keyboardType,
-              textInputAction: textInputAction,
-              style: style,
-              strutStyle: strutStyle,
-              textAlign: textAlign,
-              textAlignVertical: textAlignVertical,
-              textDirection: textDirection,
-              textCapitalization: textCapitalization,
-              autofocus: autofocus,
-              contextMenuBuilder: contextMenuBuilder,
-              readOnly: readOnly,
-              showCursor: showCursor,
-              obscureText: obscureText,
-              autocorrect: autocorrect,
-              smartDashesType: smartDashesType ??
-                  (obscureText
-                      ? SmartDashesType.disabled
-                      : SmartDashesType.enabled),
-              smartQuotesType: smartQuotesType ??
-                  (obscureText
-                      ? SmartQuotesType.disabled
-                      : SmartQuotesType.enabled),
-              enableSuggestions: enableSuggestions,
-              maxLengthEnforcement: maxLengthEnforcement,
-              maxLines: maxLines,
-              minLines: minLines,
-              expands: expands,
-              maxLength: maxLength,
-              inputFormatters: inputFormatters,
-              enabled: field.control.enabled,
-              ignorePointers: ignorePointers,
-              cursorWidth: cursorWidth,
-              cursorHeight: cursorHeight,
-              cursorRadius: cursorRadius,
-              cursorColor: cursorColor,
-              cursorErrorColor: cursorErrorColor,
-              scrollPadding: scrollPadding,
-              scrollPhysics: scrollPhysics,
-              keyboardAppearance: keyboardAppearance,
-              enableInteractiveSelection: enableInteractiveSelection,
-              buildCounter: buildCounter,
-              autofillHints: autofillHints,
-              mouseCursor: mouseCursor,
-              obscuringCharacter: obscuringCharacter,
-              dragStartBehavior: dragStartBehavior,
-              onAppPrivateCommand: onAppPrivateCommand,
-              restorationId: restorationId,
-              stylusHandwritingEnabled: stylusHandwritingEnabled,
-              scrollController: scrollController,
-              selectionControls: selectionControls,
-              selectionHeightStyle: selectionHeightStyle,
-              selectionWidthStyle: selectionWidthStyle,
-              clipBehavior: clipBehavior,
-              enableIMEPersonalizedLearning: enableIMEPersonalizedLearning,
-              onTap: onTap != null ? () => onTap(field.control) : null,
-              onSubmitted: onSubmitted != null
-                  ? (_) => onSubmitted(field.control)
-                  : null,
-              onEditingComplete: onEditingComplete != null
-                  ? () => onEditingComplete.call(field.control)
-                  : null,
-              onChanged: (value) {
-                field.didChange(value);
-                onChanged?.call(field.control);
-              },
-              undoController: undoController,
-              cursorOpacityAnimates: cursorOpacityAnimates,
-              onTapAlwaysCalled: onTapAlwaysCalled,
-              onTapOutside: onTapOutside,
-              onTapUpOutside: onTapUpOutside,
-              contentInsertionConfiguration: contentInsertionConfiguration,
-              canRequestFocus: canRequestFocus,
-              spellCheckConfiguration: spellCheckConfiguration,
-              magnifierConfiguration: magnifierConfiguration,
-              statesController: statesController,
-            );
-          },
-        );
+           return TextField(
+             groupId: groupId,
+             controller: state._textController,
+             focusNode: state.focusNode,
+             decoration: effectiveDecoration.copyWith(
+               errorText: state.errorText,
+             ),
+             keyboardType: keyboardType,
+             textInputAction: textInputAction,
+             style: style,
+             strutStyle: strutStyle,
+             textAlign: textAlign,
+             textAlignVertical: textAlignVertical,
+             textDirection: textDirection,
+             textCapitalization: textCapitalization,
+             autofocus: autofocus,
+             contextMenuBuilder: contextMenuBuilder,
+             readOnly: readOnly,
+             showCursor: showCursor,
+             obscureText: obscureText,
+             autocorrect: autocorrect,
+             smartDashesType:
+                 smartDashesType ??
+                 (obscureText
+                     ? SmartDashesType.disabled
+                     : SmartDashesType.enabled),
+             smartQuotesType:
+                 smartQuotesType ??
+                 (obscureText
+                     ? SmartQuotesType.disabled
+                     : SmartQuotesType.enabled),
+             enableSuggestions: enableSuggestions,
+             maxLengthEnforcement: maxLengthEnforcement,
+             maxLines: maxLines,
+             minLines: minLines,
+             expands: expands,
+             maxLength: maxLength,
+             inputFormatters: inputFormatters,
+             enabled: field.control.enabled,
+             ignorePointers: ignorePointers,
+             cursorWidth: cursorWidth,
+             cursorHeight: cursorHeight,
+             cursorRadius: cursorRadius,
+             cursorColor: cursorColor,
+             cursorErrorColor: cursorErrorColor,
+             scrollPadding: scrollPadding,
+             scrollPhysics: scrollPhysics,
+             keyboardAppearance: keyboardAppearance,
+             enableInteractiveSelection: enableInteractiveSelection,
+             buildCounter: buildCounter,
+             autofillHints: autofillHints,
+             mouseCursor: mouseCursor,
+             obscuringCharacter: obscuringCharacter,
+             dragStartBehavior: dragStartBehavior,
+             onAppPrivateCommand: onAppPrivateCommand,
+             restorationId: restorationId,
+             stylusHandwritingEnabled: stylusHandwritingEnabled,
+             scrollController: scrollController,
+             selectionControls: selectionControls,
+             selectionHeightStyle: selectionHeightStyle,
+             selectionWidthStyle: selectionWidthStyle,
+             clipBehavior: clipBehavior,
+             enableIMEPersonalizedLearning: enableIMEPersonalizedLearning,
+             onTap: onTap != null ? () => onTap(field.control) : null,
+             onSubmitted:
+                 onSubmitted != null ? (_) => onSubmitted(field.control) : null,
+             onEditingComplete:
+                 onEditingComplete != null
+                     ? () => onEditingComplete.call(field.control)
+                     : null,
+             onChanged: (value) {
+               field.didChange(value);
+               onChanged?.call(field.control);
+             },
+             undoController: undoController,
+             cursorOpacityAnimates: cursorOpacityAnimates,
+             onTapAlwaysCalled: onTapAlwaysCalled,
+             onTapOutside: onTapOutside,
+             onTapUpOutside: onTapUpOutside,
+             contentInsertionConfiguration: contentInsertionConfiguration,
+             canRequestFocus: canRequestFocus,
+             spellCheckConfiguration: spellCheckConfiguration,
+             magnifierConfiguration: magnifierConfiguration,
+             statesController: statesController,
+           );
+         },
+       );
 
   @override
   ReactiveFormFieldState<T, String> createState() =>
@@ -304,9 +306,10 @@ class _ReactiveTextFieldState<T>
   void _initializeTextController() {
     final initialValue = value;
     final currentWidget = widget as ReactiveTextField<T>;
-    _textController = (currentWidget._textController != null)
-        ? currentWidget._textController!
-        : TextEditingController();
+    _textController =
+        (currentWidget._textController != null)
+            ? currentWidget._textController!
+            : TextEditingController();
     _textController.text = initialValue == null ? '' : initialValue.toString();
   }
 

--- a/lib/src/widgets/reactive_time_picker.dart
+++ b/lib/src/widgets/reactive_time_picker.dart
@@ -13,11 +13,12 @@ import 'package:reactive_forms/reactive_forms.dart';
 /// that is bound to [ReactiveTimePicker].
 ///
 /// See also [ReactiveTimePickerDelegate].
-typedef ReactiveTimePickerBuilder = Widget Function(
-  BuildContext context,
-  ReactiveTimePickerDelegate picker,
-  Widget? child,
-);
+typedef ReactiveTimePickerBuilder =
+    Widget Function(
+      BuildContext context,
+      ReactiveTimePickerDelegate picker,
+      Widget? child,
+    );
 
 /// This is a convenience widget that wraps the function
 /// [showTimePicker] in a [ReactiveTimePicker].
@@ -87,42 +88,42 @@ class ReactiveTimePicker extends ReactiveFormField<TimeOfDay, TimeOfDay> {
     Icon? switchToInputEntryModeIcon,
     Icon? switchToTimerEntryModeIcon,
   }) : super(
-          builder: (ReactiveFormFieldState<TimeOfDay, TimeOfDay> field) {
-            return builder(
-              field.context,
-              ReactiveTimePickerDelegate._(
-                field,
-                (field) => showTimePicker(
-                  context: field.context,
-                  initialTime: field.value ?? TimeOfDay.now(),
-                  builder: transitionBuilder,
-                  useRootNavigator: useRootNavigator,
-                  initialEntryMode: initialEntryMode,
-                  cancelText: cancelText,
-                  confirmText: confirmText,
-                  helpText: helpText,
-                  errorInvalidText: errorInvalidText,
-                  hourLabelText: hourLabelText,
-                  minuteLabelText: minuteLabelText,
-                  routeSettings: routeSettings,
-                  onEntryModeChanged: onEntryModeChanged,
-                  anchorPoint: anchorPoint,
-                  barrierLabel: barrierLabel,
-                  barrierColor: barrierColor,
-                  barrierDismissible: barrierDismissible,
-                  orientation: orientation,
-                  switchToInputEntryModeIcon: switchToInputEntryModeIcon,
-                  switchToTimerEntryModeIcon: switchToTimerEntryModeIcon,
-                ).then((value) {
-                  if (value != null) {
-                    field.didChange(value);
-                  }
-                }),
-              ),
-              child,
-            );
-          },
-        );
+         builder: (ReactiveFormFieldState<TimeOfDay, TimeOfDay> field) {
+           return builder(
+             field.context,
+             ReactiveTimePickerDelegate._(
+               field,
+               (field) => showTimePicker(
+                 context: field.context,
+                 initialTime: field.value ?? TimeOfDay.now(),
+                 builder: transitionBuilder,
+                 useRootNavigator: useRootNavigator,
+                 initialEntryMode: initialEntryMode,
+                 cancelText: cancelText,
+                 confirmText: confirmText,
+                 helpText: helpText,
+                 errorInvalidText: errorInvalidText,
+                 hourLabelText: hourLabelText,
+                 minuteLabelText: minuteLabelText,
+                 routeSettings: routeSettings,
+                 onEntryModeChanged: onEntryModeChanged,
+                 anchorPoint: anchorPoint,
+                 barrierLabel: barrierLabel,
+                 barrierColor: barrierColor,
+                 barrierDismissible: barrierDismissible,
+                 orientation: orientation,
+                 switchToInputEntryModeIcon: switchToInputEntryModeIcon,
+                 switchToTimerEntryModeIcon: switchToTimerEntryModeIcon,
+               ).then((value) {
+                 if (value != null) {
+                   field.didChange(value);
+                 }
+               }),
+             ),
+             child,
+           );
+         },
+       );
 
   @override
   ReactiveFormFieldState<TimeOfDay, TimeOfDay> createState() =>
@@ -130,8 +131,8 @@ class ReactiveTimePicker extends ReactiveFormField<TimeOfDay, TimeOfDay> {
 }
 
 /// Definition of the function responsible for show the time picker.
-typedef _ShowTimePickerCallback = void Function(
-    ReactiveFormFieldState<TimeOfDay, TimeOfDay> field);
+typedef _ShowTimePickerCallback =
+    void Function(ReactiveFormFieldState<TimeOfDay, TimeOfDay> field);
 
 /// This class is responsible of showing the picker dialog.
 ///

--- a/lib/src/widgets/reactive_type_def.dart
+++ b/lib/src/widgets/reactive_type_def.dart
@@ -7,11 +7,12 @@ import 'package:reactive_forms/reactive_forms.dart';
 
 /// This is the definition of the builder function used in the widgets
 /// [ReactiveStatusListenableBuilder] and [ReactiveValueListenableBuilder].
-typedef ReactiveListenableWidgetBuilder<T> = Widget Function(
-  BuildContext context,
-  AbstractControl<T> control,
-  Widget? child,
-);
+typedef ReactiveListenableWidgetBuilder<T> =
+    Widget Function(
+      BuildContext context,
+      AbstractControl<T> control,
+      Widget? child,
+    );
 
 /// This is the signature to determine whether a route can popped.
 /// See [PopScope] for more details.
@@ -19,8 +20,8 @@ typedef ReactiveFormCanPopCallback = bool Function(FormGroup formGroup);
 
 /// This is the signature of the callback invoked when a route is popped.
 /// See [PopScope] for more details.
-typedef ReactiveFormPopInvokedCallback = void Function(
-    FormGroup formGroup, bool didPop);
+typedef ReactiveFormPopInvokedCallback =
+    void Function(FormGroup formGroup, bool didPop);
 
-typedef ReactiveFormPopInvokedWithResultCallback<T> = void Function(
-    FormGroup formGroup, bool didPop, T? result);
+typedef ReactiveFormPopInvokedWithResultCallback<T> =
+    void Function(FormGroup formGroup, bool didPop, T? result);

--- a/lib/src/widgets/reactive_value_listenable_builder.dart
+++ b/lib/src/widgets/reactive_value_listenable_builder.dart
@@ -44,10 +44,10 @@ class ReactiveValueListenableBuilder<T> extends StatelessWidget {
     this.formControl,
     this.child,
   }) : assert(
-          (formControlName != null && formControl == null) ||
-              (formControlName == null && formControl != null),
-          'Must provide a formControlName or a formControl, but not both at the same time.',
-        );
+         (formControlName != null && formControl == null) ||
+             (formControlName == null && formControl != null),
+         'Must provide a formControlName or a formControl, but not both at the same time.',
+       );
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 18.0.0
 homepage: "https://github.com/joanpablo/reactive_forms"
 
 environment:
-  sdk: ^3.6.0
-  flutter: ">=3.27.0"
+  sdk: ^3.7.0
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:

--- a/test/src/models/form_array_test.dart
+++ b/test/src/models/form_array_test.dart
@@ -198,7 +198,10 @@ void main() {
 
     test('Reset array with disabled states', () {
       // Given: an array with items with default values
-      final array = FormArray<int>([FormControl<int>(value: 1)]);
+      final array = FormArray<int>([FormControl<int>()]);
+
+      array.value = [1];
+      expect(array.control('0').value, 1);
 
       // And: reset array value and disable the control
       array.resetState([ControlState(disabled: true)]);
@@ -702,7 +705,8 @@ void main() {
       expect(array.value, [2, 2], reason: 'array value not patched');
     });
 
-    test('Test that markAsPending() a control, set pending status to the array '
+    test(
+        'Test that markAsPending() a control, set pending status to the array '
         'as well.', () {
       // Given: an array with valid status.
       final array = FormArray<int>([FormControl<int>(value: 1)]);

--- a/test/src/models/form_array_test.dart
+++ b/test/src/models/form_array_test.dart
@@ -705,8 +705,7 @@ void main() {
       expect(array.value, [2, 2], reason: 'array value not patched');
     });
 
-    test(
-        'Test that markAsPending() a control, set pending status to the array '
+    test('Test that markAsPending() a control, set pending status to the array '
         'as well.', () {
       // Given: an array with valid status.
       final array = FormArray<int>([FormControl<int>(value: 1)]);

--- a/test/src/models/form_control_test.dart
+++ b/test/src/models/form_control_test.dart
@@ -381,89 +381,99 @@ void main() {
 
   group('FormControl reset with initial value', () {
     test(
-        'resets to initial value if no argument is provided and initial value was not null',
-        () {
-      // Arrange
-      final control = FormControl<String>(value: 'initial');
-      control.updateValue('changed');
+      'resets to initial value if no argument is provided and initial value was not null',
+      () {
+        // Arrange
+        final control = FormControl<String>(value: 'initial');
+        control.updateValue('changed');
 
-      // Act
-      control.reset();
+        // Act
+        control.reset();
 
-      // Assert
-      expect(control.value, 'initial');
-    });
-
-    test(
-        'resets to initial value (null) if no argument is provided and initial value was null',
-        () {
-      // Arrange
-      final control = FormControl<String?>(value: null);
-      control.updateValue('changed');
-
-      // Act
-      control.reset();
-
-      // Assert
-      expect(control.value, null);
-    });
+        // Assert
+        expect(control.value, 'initial');
+      },
+    );
 
     test(
-        'resets to initial value (null) if no argument is provided and no initial value was specified (implicitly null)',
-        () {
-      // Arrange
-      final control = FormControl<String?>();
-      control.updateValue('changed');
+      'resets to initial value (null) if no argument is provided and initial value was null',
+      () {
+        // Arrange
+        final control = FormControl<String?>(value: null);
+        control.updateValue('changed');
 
-      // Act
-      control.reset();
+        // Act
+        control.reset();
 
-      // Assert
-      expect(control.value, null);
-    });
-
-    test(
-        'resets to specified value when value argument is provided, ignoring initial value',
-        () {
-      // Arrange
-      final control = FormControl<String>(value: 'initial');
-      control.updateValue('changed');
-
-      // Act
-      control.reset(value: 'newValue');
-
-      // Assert
-      expect(control.value, 'newValue');
-    });
+        // Assert
+        expect(control.value, null);
+      },
+    );
 
     test(
-        'resets to initial value when value argument is null and initial value was not null',
-        () {
-      // Arrange
-      final control = FormControl<String?>(value: 'initial');
-      control.updateValue('changed');
+      'resets to initial value (null) if no argument is provided and no initial value was specified (implicitly null)',
+      () {
+        // Arrange
+        final control = FormControl<String?>();
+        control.updateValue('changed');
 
-      // Act
-      control.reset(value: null);
+        // Act
+        control.reset();
 
-      // Assert
-      expect(control.value,
-          'initial'); // Because (value ?? _initialValue) => (null ?? "initial") => "initial"
-    });
+        // Assert
+        expect(control.value, null);
+      },
+    );
 
     test(
-        'resets to null when value argument is null and initial value was also null',
-        () {
-      // Arrange
-      final control = FormControl<String?>(value: null);
-      control.updateValue('changed');
+      'resets to specified value when value argument is provided, ignoring initial value',
+      () {
+        // Arrange
+        final control = FormControl<String>(value: 'initial');
+        control.updateValue('changed');
 
-      // Act
-      control.reset(value: null);
+        // Act
+        control.reset(value: 'newValue');
 
-      // Assert
-      expect(control.value,
-          null); // Because (value ?? _initialValue) => (null ?? null) => null
-    });
+        // Assert
+        expect(control.value, 'newValue');
+      },
+    );
+
+    test(
+      'resets to initial value when value argument is null and initial value was not null',
+      () {
+        // Arrange
+        final control = FormControl<String?>(value: 'initial');
+        control.updateValue('changed');
+
+        // Act
+        control.reset(value: null);
+
+        // Assert
+        expect(
+          control.value,
+          'initial',
+        ); // Because (value ?? _initialValue) => (null ?? "initial") => "initial"
+      },
+    );
+
+    test(
+      'resets to null when value argument is null and initial value was also null',
+      () {
+        // Arrange
+        final control = FormControl<String?>(value: null);
+        control.updateValue('changed');
+
+        // Act
+        control.reset(value: null);
+
+        // Assert
+        expect(
+          control.value,
+          null,
+        ); // Because (value ?? _initialValue) => (null ?? null) => null
+      },
+    );
   });
 }

--- a/test/src/models/form_control_test.dart
+++ b/test/src/models/form_control_test.dart
@@ -378,4 +378,92 @@ void main() {
       expect(control.pending, true);
     });
   });
+
+  group('FormControl reset with initial value', () {
+    test(
+        'resets to initial value if no argument is provided and initial value was not null',
+        () {
+      // Arrange
+      final control = FormControl<String>(value: 'initial');
+      control.updateValue('changed');
+
+      // Act
+      control.reset();
+
+      // Assert
+      expect(control.value, 'initial');
+    });
+
+    test(
+        'resets to initial value (null) if no argument is provided and initial value was null',
+        () {
+      // Arrange
+      final control = FormControl<String?>(value: null);
+      control.updateValue('changed');
+
+      // Act
+      control.reset();
+
+      // Assert
+      expect(control.value, null);
+    });
+
+    test(
+        'resets to initial value (null) if no argument is provided and no initial value was specified (implicitly null)',
+        () {
+      // Arrange
+      final control = FormControl<String?>();
+      control.updateValue('changed');
+
+      // Act
+      control.reset();
+
+      // Assert
+      expect(control.value, null);
+    });
+
+    test(
+        'resets to specified value when value argument is provided, ignoring initial value',
+        () {
+      // Arrange
+      final control = FormControl<String>(value: 'initial');
+      control.updateValue('changed');
+
+      // Act
+      control.reset(value: 'newValue');
+
+      // Assert
+      expect(control.value, 'newValue');
+    });
+
+    test(
+        'resets to initial value when value argument is null and initial value was not null',
+        () {
+      // Arrange
+      final control = FormControl<String?>(value: 'initial');
+      control.updateValue('changed');
+
+      // Act
+      control.reset(value: null);
+
+      // Assert
+      expect(control.value,
+          'initial'); // Because (value ?? _initialValue) => (null ?? "initial") => "initial"
+    });
+
+    test(
+        'resets to null when value argument is null and initial value was also null',
+        () {
+      // Arrange
+      final control = FormControl<String?>(value: null);
+      control.updateValue('changed');
+
+      // Act
+      control.reset(value: null);
+
+      // Assert
+      expect(control.value,
+          null); // Because (value ?? _initialValue) => (null ?? null) => null
+    });
+  });
 }

--- a/test/src/models/form_control_test.dart
+++ b/test/src/models/form_control_test.dart
@@ -74,7 +74,7 @@ void main() {
     });
 
     test('Reset a control set value to null', () {
-      final formControl = FormControl(value: 'john doe');
+      final formControl = FormControl<String>();
 
       formControl.value = 'hello john';
 


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #436 

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #382 

## Solution description
The `FormControl.reset()` method has been updated to align with
the common expectation that resetting a control without specifying a
new value should revert it to its initial state.

Previously, `reset()` (without arguments) would always set the
control's value to `null`.

This change introduces the following behavior:
- A `FormControl` now stores the initial value provided to its
  constructor.
- When `reset()` is called without any arguments, or if `reset(value: null)`
  is called, the control's value is set to this stored initial value.
- If `_initialValue` was `null` (e.g. `FormControl(value: null)` or
  `FormControl()`), then `reset()` or `reset(value: null)` will result
  in the control's value being `null`.
- If `reset(value: explicitValue)` is called with a non-null
  `explicitValue`, the control's value is set to `explicitValue`,
  overriding the initial value.

Unit tests have been added to cover these scenarios, ensuring
the `reset` method behaves as expected with respect to the
initial value.

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme