### PR TITLE
NumberValidatorError: static class -> enum

### DIFF
--- a/lib/src/validators/number_validator.dart
+++ b/lib/src/validators/number_validator.dart
@@ -74,11 +74,11 @@ class NumberValidator extends Validator<dynamic> {
   @override
   Map<String, dynamic>? validate(AbstractControl<dynamic> control) {
     // Skip validation if null value is allowed
-    if (allowNull && control.value == null) {
+    if (allowNull && _isControlNullOrEmptyString(control)) {
       return null;
     }
 
-    if (control.value == null) {
+    if (_isControlNullOrEmptyString(control)) {
       return <String, dynamic>{
         ValidationMessage.number: NumberValidatorError.nullValue,
       };
@@ -141,4 +141,8 @@ class NumberValidator extends Validator<dynamic> {
     // Check if the decimal part length is within the allowed limit
     return parts[1].length <= allowedDecimals;
   }
+
+  static bool _isControlNullOrEmptyString(AbstractControl<dynamic> control) =>
+      control.value == null ||
+      (control.value is String && (control.value as String).isEmpty);
 }

--- a/lib/src/validators/number_validator.dart
+++ b/lib/src/validators/number_validator.dart
@@ -43,7 +43,7 @@ import 'package:reactive_forms/src/validators/number_validator_error.dart';
 /// ```
 class NumberValidator extends Validator<dynamic> {
   /// The regex expression of a numeric string value.
-  static final RegExp notNumbersRegex = RegExp(r'[^0-9.]');
+  static final RegExp notNumbersRegex = RegExp(r'[^0-9.,]');
 
   /// The allowed number of decimal places in the validated string.
   ///
@@ -125,10 +125,11 @@ class NumberValidator extends Validator<dynamic> {
   }
 
   bool _validateNumberDecimals(int allowedDecimals, String numberString) {
+    final deLocalizedNumberString = numberString.replaceAll(',', '.');
     // Split the number string at the decimal point
-    final parts = numberString.split('.');
+    final parts = deLocalizedNumberString.split('.');
 
-    if (parts.length > 2 || numberString == '.' || numberString.endsWith('.')) {
+    if (parts.length > 2 || deLocalizedNumberString == '.' || deLocalizedNumberString.endsWith('.')) {
       // More than one decimal point, invalid format
       return false;
     }

--- a/lib/src/validators/number_validator_error.dart
+++ b/lib/src/validators/number_validator_error.dart
@@ -1,6 +1,6 @@
-class NumberValidatorError {
-  static const String nullValue = 'nullValue';
-  static const String invalidDecimals = 'invalidDecimals';
-  static const String unsignedNumber = 'unsignedNumber';
-  static const String invalidNumber = 'invalidNumber';
+enum NumberValidatorError {
+  nullValue,
+  invalidDecimals,
+  unsignedNumber,
+  invalidNumber,
 }


### PR DESCRIPTION
## Solution description
Convert a static class with string constants to an enum.

The static class has an exhaustive number of errors. At the moment, this means that a caller receives a String as the error and has manually match it using the key of the static class. Just using an enums solves this problem and also allows more effective pattern matching. The enum instead of static classes also allow it to be used directly in frameworks that require enums to directly define translations like [slang](https://pub.dev/packages/slang).

Also fixes the differnce n behaviour when using with a locale that uses a `,` as a separator instead of a `.`.

## Considerations
Enum field names match their previous key names. This would mean an easy migration by appending `.name` to the usage if it was being interpolated

## To Do

- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme