### PR TITLE
Fix for fb: group with DateTime or TimeOfDay value and a validator as array

### DIFF
--- a/lib/src/models/form_builder.dart
+++ b/lib/src/models/form_builder.dart
@@ -244,9 +244,9 @@ class FormBuilder {
     } else if (value is double) {
       return FormControl<double>(value: value, validators: validators);
     } else if (value is DateTime) {
-      return FormControl<DateTime>(value: value);
+      return FormControl<DateTime>(value: value, validators: validators);
     } else if (value is TimeOfDay) {
-      return FormControl<TimeOfDay>(value: value);
+      return FormControl<TimeOfDay>(value: value, validators: validators);
     }
 
     return FormControl<dynamic>(value: value, validators: validators);

--- a/test/src/models/form_builder_test.dart
+++ b/test/src/models/form_builder_test.dart
@@ -422,8 +422,8 @@ void main() {
 
       // Expect a form group created
       expect(
-        form.control('control') is FormControl<DateTime>,
-        true,
+        form.control('control'),
+        isA<FormControl<DateTime>>(),
         reason:
         '${form.control('control').runtimeType} is not instance of FormControl<DateTime>',
       );
@@ -433,13 +433,8 @@ void main() {
         reason: 'control default value not set',
       );
       expect(
-          form.control('control').validators.length,
-          1,
-          reason: 'incorrect validators length'
-      );
-      expect(
-        form.control('control').validators[0],
-        requiredValidator,
+        form.control('control').validators,
+        [requiredValidator],
         reason: 'not set required validator'
       );
     });
@@ -477,8 +472,8 @@ void main() {
 
       // Expect a form group created
       expect(
-        form.control('control') is FormControl<TimeOfDay>,
-        true,
+        form.control('control'),
+        isA<FormControl<TimeOfDay>>(),
         reason:
         '${form.control('control').runtimeType} is not instance of FormControl<TimeOfDay>',
       );
@@ -488,13 +483,8 @@ void main() {
         reason: 'control default value not set',
       );
       expect(
-          form.control('control').validators.length,
-          1,
-          reason: 'incorrect validators length'
-      );
-      expect(
-          form.control('control').validators[0],
-          requiredValidator,
+          form.control('control').validators,
+          [requiredValidator],
           reason: 'not set required validator'
       );
     });

--- a/test/src/models/form_builder_test.dart
+++ b/test/src/models/form_builder_test.dart
@@ -411,6 +411,40 @@ void main() {
       );
     });
 
+
+    test('Build a group with default datetime value and a validator as array', () {
+      // Given: a form group builder creation
+      final requiredValidator = Validators.required;
+      final value = DateTime.now();
+      final form = fb.group({
+        'control': [value, requiredValidator],
+      });
+
+      // Expect a form group created
+      expect(
+        form.control('control') is FormControl<DateTime>,
+        true,
+        reason:
+        '${form.control('control').runtimeType} is not instance of FormControl<DateTime>',
+      );
+      expect(
+        form.control('control').value,
+        value,
+        reason: 'control default value not set',
+      );
+      expect(
+          form.control('control').validators.length,
+          1,
+          reason: 'incorrect validators length'
+      );
+      expect(
+        form.control('control').validators[0],
+        requiredValidator,
+        reason: 'not set required validator'
+      );
+    });
+
+
     test('Build a group with default TimeOfDay value as array', () {
       // Given: a form group builder creation
       final value = TimeOfDay.now();
@@ -429,6 +463,39 @@ void main() {
         form.control('control').value,
         value,
         reason: 'control default value not set',
+      );
+    });
+
+
+    test('Build a group with default TimeOfDay value and a validator as array', () {
+      // Given: a form group builder creation
+      final requiredValidator = Validators.required;
+      final value = TimeOfDay.now();
+      final form = fb.group({
+        'control': [value, requiredValidator],
+      });
+
+      // Expect a form group created
+      expect(
+        form.control('control') is FormControl<TimeOfDay>,
+        true,
+        reason:
+        '${form.control('control').runtimeType} is not instance of FormControl<TimeOfDay>',
+      );
+      expect(
+        form.control('control').value,
+        value,
+        reason: 'control default value not set',
+      );
+      expect(
+          form.control('control').validators.length,
+          1,
+          reason: 'incorrect validators length'
+      );
+      expect(
+          form.control('control').validators[0],
+          requiredValidator,
+          reason: 'not set required validator'
       );
     });
 


### PR DESCRIPTION
## Connection with issue(s)

Close #428 

## Solution description

Fixes a bug with FormBuilder: when creating a from group with a DateTime or TimeOfDay value and a validator using array syntax, the validator is not added to the created FormControl.

For example, when creating a form group like this:
```dart
final form = fb.group({
   'control': [DateTime.now(), Validators.required],
});
```

the resultant FormControl (named 'control' in the example) is missing the validator.

## Screenshots or Videos

## To Do

- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme