### PR TITLE
[#504] Guard asyncValidator setting error with `_statusChanges` stream status

### DIFF
--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -471,6 +471,7 @@ abstract class AbstractControl<T> {
     _statusChanges.close();
     _valueChanges.close();
     _asyncValidationSubscription?.cancel();
+    _debounceTimer?.cancel();
   }
 
   /// Sets the value of the control.
@@ -706,8 +707,8 @@ abstract class AbstractControl<T> {
     _updateAncestors(updateParent);
   }
 
-  Future<void> _cancelExistingSubscription() async {
-    await _asyncValidationSubscription?.cancel();
+  void _cancelExistingSubscription() {
+    _asyncValidationSubscription?.cancel();
     _asyncValidationSubscription = null;
   }
 
@@ -760,8 +761,6 @@ abstract class AbstractControl<T> {
         }
       },
       onDone: () {
-        if (_statusChanges.isClosed) return;
-
         final allErrors = <String, dynamic>{};
         allErrors.addAll(errors);
         allErrors.addAll(asyncValidationErrors);

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -760,6 +760,8 @@ abstract class AbstractControl<T> {
         }
       },
       onDone: () {
+        if (_statusChanges.isClosed) return;
+
         final allErrors = <String, dynamic>{};
         allErrors.addAll(errors);
         allErrors.addAll(asyncValidationErrors);

--- a/test/src/validators/async_validator_test.dart
+++ b/test/src/validators/async_validator_test.dart
@@ -325,15 +325,11 @@ void main() {
     group('Dispose during in-flight async validation', () {
       test('FormControl disposed mid-flight does not throw', () {
         fakeAsync((async) {
-          var validatorRan = false;
           final control = FormControl<String>(
             asyncValidators: [
               Validators.delegateAsync(
                 (control) =>
-                    Future.delayed(const Duration(milliseconds: 100), () {
-                      validatorRan = true;
-                      return null;
-                    }),
+                    Future.delayed(const Duration(milliseconds: 100), () => null),
               ),
             ],
           );
@@ -349,12 +345,6 @@ void main() {
           // Advance past the global debounce (250ms) plus the validator's
           // delay so the orphaned future resolves and the stream completes.
           async.elapse(const Duration(milliseconds: 500));
-
-          expect(
-            validatorRan,
-            true,
-            reason: 'The async validator future should still resolve',
-          );
         });
       });
 
@@ -475,6 +465,88 @@ void main() {
           });
         },
       );
+
+      test('Dispose cancels the pending debounce timer', () {
+        fakeAsync((async) {
+          final control = FormControl<String>(
+            asyncValidators: [
+              Validators.delegateAsync(
+                (control) =>
+                    Future.delayed(const Duration(milliseconds: 100), () => null),
+              ),
+            ],
+          );
+
+          control.value = 'x';
+          expect(
+            async.pendingTimers,
+            isNotEmpty,
+            reason:
+                'A debounce timer should be scheduled after a value change',
+          );
+
+          control.dispose();
+
+          expect(
+            async.pendingTimers,
+            isEmpty,
+            reason:
+                'Dispose should cancel the pending debounce timer so it cannot '
+                'fire the validator after the streams have been closed',
+          );
+        });
+      });
+    });
+
+    // Regression test for the underlying race that caused the use-after-free
+    // crash in issue #504. The bug: `_cancelExistingSubscription` was async and
+    // awaited `subscription.cancel()`; the suspension point allowed
+    // `_runAsyncValidators` to assign a fresh subscription before the
+    // continuation set `_asyncValidationSubscription = null`, orphaning it.
+    // Because the orphan was never cancelled on a subsequent value change, its
+    // stale result could overwrite the latest validator's result.
+    group('Async validator subscription cancellation', () {
+      test('Stale async validator result does not overwrite latest', () {
+        fakeAsync((async) {
+          // Validator behaviour is value-dependent. The captured value is
+          // fixed at validator-invocation time so the closure stays
+          // consistent even if the control's value changes afterwards.
+          //   'bad'  → slow (200ms), returns {'invalid': true}
+          //   'good' → fast (50ms),  returns no error
+          //
+          // If the 'bad' subscription is correctly cancelled when the value
+          // becomes 'good', the stale error never reaches the control. With
+          // the orphan race, the 'bad' subscription survives, fires onDone
+          // after 'good' has already settled, and re-injects the stale error
+          // into the control's error map.
+          final control = FormControl<String>(
+            // ignore: deprecated_member_use_from_same_package
+            asyncValidatorsDebounceTime: 0,
+            asyncValidators: [
+              Validators.delegateAsync((c) {
+                final captured = c.value;
+                return Future.delayed(
+                  Duration(milliseconds: captured == 'bad' ? 200 : 50),
+                  () => captured == 'bad' ? {'invalid': true} : null,
+                );
+              }),
+            ],
+          );
+
+          control.value = 'bad';
+          async.elapse(const Duration(milliseconds: 50));
+          control.value = 'good';
+          async.elapse(const Duration(milliseconds: 300));
+
+          expect(
+            control.hasError('invalid'),
+            false,
+            reason:
+                'A stale validator result for "bad" must not survive after '
+                'the value has been changed to "good"',
+          );
+        });
+      });
     });
   });
 }

--- a/test/src/validators/async_validator_test.dart
+++ b/test/src/validators/async_validator_test.dart
@@ -315,5 +315,166 @@ void main() {
         );
       },
     );
+
+    // Regression tests for https://github.com/joanpablo/reactive_forms/issues/504
+    //
+    // When a control is disposed while an async validator is still in flight,
+    // the validator's `onDone` callback used to fire after `_statusChanges`
+    // was already closed, throwing
+    // `StateError: Cannot add new events after calling close`.
+    group('Dispose during in-flight async validation', () {
+      test('FormControl disposed mid-flight does not throw', () {
+        fakeAsync((async) {
+          var validatorRan = false;
+          final control = FormControl<String>(
+            asyncValidators: [
+              Validators.delegateAsync(
+                (control) =>
+                    Future.delayed(const Duration(milliseconds: 100), () {
+                      validatorRan = true;
+                      return null;
+                    }),
+              ),
+            ],
+          );
+
+          control.value = 'some value';
+          expect(control.pending, true);
+
+          // Dispose part-way through the debounce window so the timer
+          // outlives the subscription's cancellation.
+          async.elapse(const Duration(milliseconds: 100));
+          control.dispose();
+
+          // Advance past the global debounce (250ms) plus the validator's
+          // delay so the orphaned future resolves and the stream completes.
+          async.elapse(const Duration(milliseconds: 500));
+
+          expect(
+            validatorRan,
+            true,
+            reason: 'The async validator future should still resolve',
+          );
+        });
+      });
+
+      test(
+        'FormControl disposed mid-flight does not throw when validator returns errors',
+        () {
+          fakeAsync((async) {
+            final control = FormControl<String>(
+              asyncValidators: [
+                Validators.delegateAsync(
+                  (control) => Future.delayed(
+                    const Duration(milliseconds: 100),
+                    () => {'unique': true},
+                  ),
+                ),
+              ],
+            );
+
+            control.value = 'some value';
+            async.elapse(const Duration(milliseconds: 100));
+            control.dispose();
+
+            // Without the guard, onDone would call setErrors → _statusChanges.add
+            // on a closed controller and throw StateError.
+            async.elapse(const Duration(milliseconds: 500));
+          });
+        },
+      );
+
+      test('FormControl disposed during debounce window does not throw', () {
+        fakeAsync((async) {
+          final control = FormControl<String>(
+            asyncValidators: [
+              Validators.delegateAsync(
+                (control) =>
+                    Future.delayed(const Duration(milliseconds: 100), () => null),
+                debounceTime: 500,
+              ),
+            ],
+          );
+
+          control.value = 'some value';
+
+          // Dispose while still inside the debounce window — the timer is
+          // armed but the validator hasn't started yet.
+          async.elapse(const Duration(milliseconds: 100));
+          control.dispose();
+
+          // Advance well past debounce + validator delay.
+          async.elapse(const Duration(milliseconds: 1000));
+        });
+      });
+
+      test(
+        'FormGroup disposed while a child async validator is in flight does not throw',
+        () {
+          fakeAsync((async) {
+            final form = FormGroup({
+              'name': FormControl<String>(
+                asyncValidators: [
+                  Validators.delegateAsync(
+                    (control) => Future.delayed(
+                      const Duration(milliseconds: 100),
+                      () => {'taken': true},
+                    ),
+                  ),
+                ],
+              ),
+            });
+
+            form.control('name').value = 'some value';
+            expect(form.pending, true);
+
+            // Disposing the parent cascades dispose() to children.
+            async.elapse(const Duration(milliseconds: 100));
+            form.dispose();
+
+            async.elapse(const Duration(milliseconds: 500));
+          });
+        },
+      );
+
+      test(
+        'FormControl disposed with multiple in-flight async validators does not throw',
+        () {
+          fakeAsync((async) {
+            final control = FormControl<String>(
+              asyncValidators: [
+                Validators.delegateAsync(
+                  (control) => Future.delayed(
+                    const Duration(milliseconds: 100),
+                    () => null,
+                  ),
+                ),
+                Validators.delegateAsync(
+                  (control) => Future.delayed(
+                    const Duration(milliseconds: 200),
+                    () => {'other': true},
+                  ),
+                ),
+                Validators.debounced(
+                  Validators.delegateAsync(
+                    (control) => Future.delayed(
+                      const Duration(milliseconds: 150),
+                      () => null,
+                    ),
+                  ),
+                  300,
+                ),
+              ],
+            );
+
+            control.value = 'some value';
+            async.elapse(const Duration(milliseconds: 100));
+            control.dispose();
+
+            async.elapse(const Duration(milliseconds: 1000));
+          });
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
## Connection with issue(s)

Close #504

## Solution description

The `StateError: Cannot add new events after calling close` from #504 is the visible symptom of an orphan-subscription race in `_cancelExistingSubscription()`. The same race can also cause stale validator results to overwrite newer ones, even without `dispose()`.

### Root cause

`_cancelExistingSubscription()` was `async` and called without `await` from `updateValueAndValidity()`:

```dart
Future<void> _cancelExistingSubscription() async {
  await _asyncValidationSubscription?.cancel();
  _asyncValidationSubscription = null;
}
```

1. The `await` suspends — even when `_asyncValidationSubscription` is `null`, `await null` still yields via a microtask.
2. Control returns to `updateValueAndValidity()`, which synchronously runs `_runAsyncValidators()` and stores a fresh subscription in `_asyncValidationSubscription`.
3. The deferred microtask resumes and runs `_asyncValidationSubscription = null`, **orphaning the just-assigned subscription**.
4. The orphan has no reference, so neither subsequent value changes nor `dispose()` can cancel it. When it eventually completes, its `onDone`:
   - crashes if `_statusChanges` has been closed (the original #504 symptom), or
   - re-injects a stale error via `setErrors(...).addAll(errors).addAll(asyncValidationErrors)`, overwriting whatever the latest validator settled on.

### Fix

1. Make `_cancelExistingSubscription` synchronous. `StreamSubscription.cancel()` stops event delivery synchronously; the returned future only signals cleanup completion, so awaiting it serves no purpose here and is what introduces the suspension point.
2. Cancel `_debounceTimer` in `dispose()`. Without this, disposing a control while a debounce window is open leaks the timer (and the closure holding `this`).

With both changes the symptom-level `if (_statusChanges.isClosed) return;` guard is unnecessary — the orphan that produced the bad `onDone` can no longer be created.

## Tests

`test/src/validators/async_validator_test.dart`:

- **`Dispose during in-flight async validation`** — six tests covering dispose at various points during validation for `FormControl` / `FormGroup`, single and multiple validators, including the debounce window. Also asserts `dispose()` cancels the pending debounce timer via `FakeAsync.pendingTimers`.
- **`Async validator subscription cancellation`** — sets `value = 'bad'` (slow validator, returns an error), then `value = 'good'` (fast, returns no error); asserts the stale `'bad'` error does not survive into the `'good'` state. Fails on the original code because the orphaned `'bad'` subscription is never cancelled and re-injects its error after `'good'` has already settled.

Each test was verified to fail when the corresponding part of the fix is reverted.

## To Do

- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme