### PR TITLE
feat: use decoupled material-ui

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,14 @@
 include: package:lints/recommended.yaml
 
 analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   language:
     strict-casts: true
     strict-inference: true

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 void main() {

--- a/lib/src/models/form_builder.dart
+++ b/lib/src/models/form_builder.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// Creates an [AbstractControl] from a user-specified configuration.

--- a/lib/src/value_accessors/time_of_day_value_accessor.dart
+++ b/lib/src/value_accessors/time_of_day_value_accessor.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// Represents a control value accessor that convert between data types

--- a/lib/src/widgets/form_control_inherited_notifier.dart
+++ b/lib/src/widgets/form_control_inherited_notifier.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// Represents an Inherited Widget that exposes an [AbstractControl]

--- a/lib/src/widgets/inherited_streamer.dart
+++ b/lib/src/widgets/inherited_streamer.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 abstract class InheritedStreamer<T> extends InheritedWidget {
   const InheritedStreamer(this.stream, Widget child, {super.key})

--- a/lib/src/widgets/reactive_checkbox.dart
+++ b/lib/src/widgets/reactive_checkbox.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// This is a convenience widget that wraps a [Checkbox] widget in a

--- a/lib/src/widgets/reactive_checkbox_list_tile.dart
+++ b/lib/src/widgets/reactive_checkbox_list_tile.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// This is a convenience widget that wraps a [CheckboxListTile] widget in a

--- a/lib/src/widgets/reactive_date_picker.dart
+++ b/lib/src/widgets/reactive_date_picker.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// A builder that builds a widget responsible to decide when to show

--- a/lib/src/widgets/reactive_dropdown_field.dart
+++ b/lib/src/widgets/reactive_dropdown_field.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// A reactive widget that wraps a [DropdownButtonFormField].

--- a/lib/src/widgets/reactive_form.dart
+++ b/lib/src/widgets/reactive_form.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 import 'package:reactive_forms/src/widgets/form_control_inherited_notifier.dart';
 

--- a/lib/src/widgets/reactive_form_array.dart
+++ b/lib/src/widgets/reactive_form_array.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 import '../widgets/form_control_inherited_notifier.dart';

--- a/lib/src/widgets/reactive_form_builder.dart
+++ b/lib/src/widgets/reactive_form_builder.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 import 'package:reactive_forms/src/widgets/form_control_inherited_notifier.dart';
 

--- a/lib/src/widgets/reactive_form_consumer.dart
+++ b/lib/src/widgets/reactive_form_consumer.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// Builder function definition of the [ReactiveFormConsumer] builder.

--- a/lib/src/widgets/reactive_form_field.dart
+++ b/lib/src/widgets/reactive_form_field.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// Signature for building the widget representing the form field.

--- a/lib/src/widgets/reactive_form_pop_scope.dart
+++ b/lib/src/widgets/reactive_form_pop_scope.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 @optionalTypeArgs

--- a/lib/src/widgets/reactive_radio.dart
+++ b/lib/src/widgets/reactive_radio.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// This is a convenience widget that wraps a [Radio] widget in a

--- a/lib/src/widgets/reactive_radio_list_tile.dart
+++ b/lib/src/widgets/reactive_radio_list_tile.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// This is a convenience widget that wraps a [RadioListTile] widget in a

--- a/lib/src/widgets/reactive_slider.dart
+++ b/lib/src/widgets/reactive_slider.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// Signature for callbacks that are used to get

--- a/lib/src/widgets/reactive_status_listenable_builder.dart
+++ b/lib/src/widgets/reactive_status_listenable_builder.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// This widget listen for changes in the status of a [FormControl] specified

--- a/lib/src/widgets/reactive_switch.dart
+++ b/lib/src/widgets/reactive_switch.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// This is a convenience widget that wraps a [Switch] widget in a

--- a/lib/src/widgets/reactive_switch_list_tile.dart
+++ b/lib/src/widgets/reactive_switch_list_tile.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// This is a convenience widget that wraps a [SwitchListTile] widget in a

--- a/lib/src/widgets/reactive_text_field.dart
+++ b/lib/src/widgets/reactive_text_field.dart
@@ -5,7 +5,7 @@
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/lib/src/widgets/reactive_time_picker.dart
+++ b/lib/src/widgets/reactive_time_picker.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// A builder that builds a widget responsible to decide when to show

--- a/lib/src/widgets/reactive_type_def.dart
+++ b/lib/src/widgets/reactive_type_def.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// This is the definition of the builder function used in the widgets

--- a/lib/src/widgets/reactive_value_listenable_builder.dart
+++ b/lib/src/widgets/reactive_value_listenable_builder.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 /// A widget whose content stays synced with a [ValueListenable].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
     sdk: flutter
   intl: ">=0.18.1 <1.0.0"
 
+  material_ui: any
 dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_test:

--- a/test/src/models/form_builder_test.dart
+++ b/test/src/models/form_builder_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/value_accessors/time_of_day_value_accessor_test.dart
+++ b/test/src/value_accessors/time_of_day_value_accessor_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_checkbox_list_tile_test.dart
+++ b/test/src/widgets/reactive_checkbox_list_tile_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_checkbox_list_tile_testing_widget.dart
+++ b/test/src/widgets/reactive_checkbox_list_tile_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 const reactiveCheckboxListTileTestingName = 'isChecked';

--- a/test/src/widgets/reactive_checkbox_test.dart
+++ b/test/src/widgets/reactive_checkbox_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_checkbox_testing_widget.dart
+++ b/test/src/widgets/reactive_checkbox_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 const reactiveCheckboxTestingName = 'isChecked';

--- a/test/src/widgets/reactive_date_picker_test.dart
+++ b/test/src/widgets/reactive_date_picker_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_date_picker_testing_widget.dart
+++ b/test/src/widgets/reactive_date_picker_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class ReactiveDatePickerTestingWidget<T> extends StatelessWidget {

--- a/test/src/widgets/reactive_dropdown_field_test.dart
+++ b/test/src/widgets/reactive_dropdown_field_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_dropdown_testing_widget.dart
+++ b/test/src/widgets/reactive_dropdown_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class ReactiveDropdownTestingWidget extends StatelessWidget {

--- a/test/src/widgets/reactive_form_array_test.dart
+++ b/test/src/widgets/reactive_form_array_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_form_array_testing_widget.dart
+++ b/test/src/widgets/reactive_form_array_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class ReactiveFormArrayTestingWidget extends StatelessWidget {

--- a/test/src/widgets/reactive_form_builder_test.dart
+++ b/test/src/widgets/reactive_form_builder_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_form_builder_testing_widget.dart
+++ b/test/src/widgets/reactive_form_builder_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class ReactiveFormBuilderTestingWidget<T> extends StatelessWidget {

--- a/test/src/widgets/reactive_form_config_test.dart
+++ b/test/src/widgets/reactive_form_config_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_form_consumer_test.dart
+++ b/test/src/widgets/reactive_form_consumer_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_form_consumer_testing_widget.dart
+++ b/test/src/widgets/reactive_form_consumer_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class ReactiveFormConsumerTestingWidget extends StatelessWidget {

--- a/test/src/widgets/reactive_form_field_test.dart
+++ b/test/src/widgets/reactive_form_field_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_radio_list_tile_test.dart
+++ b/test/src/widgets/reactive_radio_list_tile_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_radio_list_tile_testing_widget.dart
+++ b/test/src/widgets/reactive_radio_list_tile_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 const reactiveRadioListTileTestingName = 'radio';

--- a/test/src/widgets/reactive_radio_test.dart
+++ b/test/src/widgets/reactive_radio_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_radio_testing_widget.dart
+++ b/test/src/widgets/reactive_radio_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 const reactiveRadioTestingName = 'radio';

--- a/test/src/widgets/reactive_slider_test.dart
+++ b/test/src/widgets/reactive_slider_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_slider_testing_widget.dart
+++ b/test/src/widgets/reactive_slider_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 const reactiveSliderTestingName = 'sliderValue';

--- a/test/src/widgets/reactive_status_listenable_builder_testing_widget.dart
+++ b/test/src/widgets/reactive_status_listenable_builder_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class ReactiveStatusListenableTestingWidget extends StatelessWidget {

--- a/test/src/widgets/reactive_switch_list_tile_test.dart
+++ b/test/src/widgets/reactive_switch_list_tile_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_switch_list_tile_testing_widget.dart
+++ b/test/src/widgets/reactive_switch_list_tile_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 const switchListTileControl = 'switchListTile';

--- a/test/src/widgets/reactive_switch_test.dart
+++ b/test/src/widgets/reactive_switch_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_switch_testing_widget.dart
+++ b/test/src/widgets/reactive_switch_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 final reactiveSwitchTestingName = 'switch';

--- a/test/src/widgets/reactive_text_field_test.dart
+++ b/test/src/widgets/reactive_text_field_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_text_field_testing_widget.dart
+++ b/test/src/widgets/reactive_text_field_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class ReactiveTextFieldTestingWidget<T> extends StatelessWidget {

--- a/test/src/widgets/reactive_time_picker_test.dart
+++ b/test/src/widgets/reactive_time_picker_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 

--- a/test/src/widgets/reactive_time_picker_testing_widget.dart
+++ b/test/src/widgets/reactive_time_picker_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class ReactiveTimePickerTestingWidget extends StatelessWidget {

--- a/test/src/widgets/reactive_value_listenable_builder_testing_widget.dart
+++ b/test/src/widgets/reactive_value_listenable_builder_testing_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class ReactiveValueListenableTestingWidget extends StatelessWidget {


### PR DESCRIPTION
## Connection with issue(s)

N/A

## Solution description

The material library has been decoupled from the Flutter SDK and released as its own package. It will be removed from the SDK in future versions. This PR moves all the imports to use the decoupled package. This PR is the result of running `dart fix --apply --code=migrate_design_widgets` as suggested by the the SDK 3.47.0 release notes.

The release notes also suggest that such a change in a library should ideally be made as a major release.

## Screenshots or Videos

N/A

## To Do

- [ ] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme